### PR TITLE
Apply cargo fmt to fix CI formatting check

### DIFF
--- a/crates/ochra-crypto/src/argon2id.rs
+++ b/crates/ochra-crypto/src/argon2id.rs
@@ -135,8 +135,10 @@ mod tests {
     #[test]
     fn test_derive_key_different_salts() {
         let password = b"password";
-        let key1 = derive_key_custom(password, b"salt111111111111", 1024, 1, 1, 32).expect("derive");
-        let key2 = derive_key_custom(password, b"salt222222222222", 1024, 1, 1, 32).expect("derive");
+        let key1 =
+            derive_key_custom(password, b"salt111111111111", 1024, 1, 1, 32).expect("derive");
+        let key2 =
+            derive_key_custom(password, b"salt222222222222", 1024, 1, 1, 32).expect("derive");
         assert_ne!(key1, key2);
     }
 

--- a/crates/ochra-crypto/src/blake3.rs
+++ b/crates/ochra-crypto/src/blake3.rs
@@ -199,7 +199,10 @@ mod tests {
 
         // All context strings should start with "Ochra v1 "
         for ctx in contexts::ALL_CONTEXTS {
-            assert!(ctx.starts_with("Ochra v1 "), "Context string '{ctx}' has wrong prefix");
+            assert!(
+                ctx.starts_with("Ochra v1 "),
+                "Context string '{ctx}' has wrong prefix"
+            );
         }
     }
 

--- a/crates/ochra-crypto/src/chacha20.rs
+++ b/crates/ochra-crypto/src/chacha20.rs
@@ -31,7 +31,12 @@ pub const TAG_SIZE: usize = 16;
 /// # Returns
 ///
 /// Ciphertext with appended 16-byte authentication tag.
-pub fn encrypt(key: &[u8; KEY_SIZE], nonce: &[u8; NONCE_SIZE], plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt(
+    key: &[u8; KEY_SIZE],
+    nonce: &[u8; NONCE_SIZE],
+    plaintext: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>> {
     let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
     let nonce = Nonce::from_slice(nonce);
 
@@ -58,7 +63,12 @@ pub fn encrypt(key: &[u8; KEY_SIZE], nonce: &[u8; NONCE_SIZE], plaintext: &[u8],
 /// # Returns
 ///
 /// Decrypted plaintext, or error if authentication fails.
-pub fn decrypt(key: &[u8; KEY_SIZE], nonce: &[u8; NONCE_SIZE], ciphertext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
+pub fn decrypt(
+    key: &[u8; KEY_SIZE],
+    nonce: &[u8; NONCE_SIZE],
+    ciphertext: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>> {
     let cipher = ChaCha20Poly1305::new(Key::from_slice(key));
     let nonce = Nonce::from_slice(nonce);
 
@@ -74,12 +84,20 @@ pub fn decrypt(key: &[u8; KEY_SIZE], nonce: &[u8; NONCE_SIZE], ciphertext: &[u8]
 }
 
 /// Encrypt data without additional authenticated data.
-pub fn encrypt_no_aad(key: &[u8; KEY_SIZE], nonce: &[u8; NONCE_SIZE], plaintext: &[u8]) -> Result<Vec<u8>> {
+pub fn encrypt_no_aad(
+    key: &[u8; KEY_SIZE],
+    nonce: &[u8; NONCE_SIZE],
+    plaintext: &[u8],
+) -> Result<Vec<u8>> {
     encrypt(key, nonce, plaintext, &[])
 }
 
 /// Decrypt data without additional authenticated data.
-pub fn decrypt_no_aad(key: &[u8; KEY_SIZE], nonce: &[u8; NONCE_SIZE], ciphertext: &[u8]) -> Result<Vec<u8>> {
+pub fn decrypt_no_aad(
+    key: &[u8; KEY_SIZE],
+    nonce: &[u8; NONCE_SIZE],
+    ciphertext: &[u8],
+) -> Result<Vec<u8>> {
     decrypt(key, nonce, ciphertext, &[])
 }
 

--- a/crates/ochra-crypto/src/ecies.rs
+++ b/crates/ochra-crypto/src/ecies.rs
@@ -110,10 +110,7 @@ pub fn encrypt(recipient_pk: &X25519PublicKey, plaintext: &[u8]) -> Result<Ecies
 ///
 /// * `recipient_sk` - Recipient's X25519 static secret
 /// * `ciphertext` - The ECIES ciphertext (eph_pk || ciphertext || tag)
-pub fn decrypt(
-    recipient_sk: &X25519StaticSecret,
-    ciphertext: &EciesCiphertext,
-) -> Result<Vec<u8>> {
+pub fn decrypt(recipient_sk: &X25519StaticSecret, ciphertext: &EciesCiphertext) -> Result<Vec<u8>> {
     let eph_pk = X25519PublicKey::from_bytes(ciphertext.eph_pk);
     let recipient_pk = recipient_sk.public_key();
 
@@ -136,7 +133,12 @@ pub fn decrypt(
     nonce.copy_from_slice(&nonce_full[..12]);
 
     // Step 5: Decrypt with AAD = eph_pk
-    chacha20::decrypt(&enc_key, &nonce, &ciphertext.ciphertext_and_tag, &ciphertext.eph_pk)
+    chacha20::decrypt(
+        &enc_key,
+        &nonce,
+        &ciphertext.ciphertext_and_tag,
+        &ciphertext.eph_pk,
+    )
 }
 
 #[cfg(test)]

--- a/crates/ochra-crypto/src/ed25519.rs
+++ b/crates/ochra-crypto/src/ed25519.rs
@@ -254,10 +254,8 @@ mod tests {
     #[test]
     fn test_sign_verify_with_known_seed() {
         // Use a known seed, sign, and verify roundtrip
-        let seed = hex::decode(
-            "9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60",
-        )
-        .expect("valid hex");
+        let seed = hex::decode("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60")
+            .expect("valid hex");
         let mut seed_bytes = [0u8; 32];
         seed_bytes.copy_from_slice(&seed);
         let kp = KeyPair::from_bytes(&seed_bytes);

--- a/crates/ochra-crypto/src/frost.rs
+++ b/crates/ochra-crypto/src/frost.rs
@@ -60,9 +60,13 @@ pub fn dkg(
 
     // Use the trusted dealer key generation for simplicity in v1
     // (Production should use the 3-round DKG from Section 12.6)
-    let (shares, pubkey_package) =
-        frost::keys::generate_with_dealer(max_signers, min_signers, frost::keys::IdentifierList::Default, &mut rng)
-            .map_err(|e| CryptoError::Frost(e.to_string()))?;
+    let (shares, pubkey_package) = frost::keys::generate_with_dealer(
+        max_signers,
+        min_signers,
+        frost::keys::IdentifierList::Default,
+        &mut rng,
+    )
+    .map_err(|e| CryptoError::Frost(e.to_string()))?;
 
     let key_packages: Vec<FrostKeyPackage> = shares
         .into_values()
@@ -172,7 +176,8 @@ mod tests {
         let message = b"test message for FROST signing";
 
         // Round 1: First 3 signers generate nonces
-        let mut commitments_map: BTreeMap<frost::Identifier, frost::round1::SigningCommitments> = BTreeMap::new();
+        let mut commitments_map: BTreeMap<frost::Identifier, frost::round1::SigningCommitments> =
+            BTreeMap::new();
         let mut signing_nonces = Vec::new();
 
         for kp in key_packages.iter().take(3) {
@@ -192,8 +197,8 @@ mod tests {
         }
 
         // Aggregate
-        let signature = aggregate(&signing_package, &signature_shares, &pubkey_package)
-            .expect("aggregate");
+        let signature =
+            aggregate(&signing_package, &signature_shares, &pubkey_package).expect("aggregate");
 
         // Verify
         verify_group_signature(message, &signature, &pubkey_package).expect("verify");
@@ -209,7 +214,8 @@ mod tests {
         let message = b"test";
 
         // Get 3 commitments (required for signing package) but only 2 shares
-        let mut commitments_map: BTreeMap<frost::Identifier, frost::round1::SigningCommitments> = BTreeMap::new();
+        let mut commitments_map: BTreeMap<frost::Identifier, frost::round1::SigningCommitments> =
+            BTreeMap::new();
         let mut signing_nonces = Vec::new();
 
         for kp in key_packages.iter().take(3) {
@@ -229,6 +235,9 @@ mod tests {
 
         // Aggregation with insufficient shares should fail
         let result = aggregate(&signing_package, &signature_shares, &pubkey_package);
-        assert!(result.is_err(), "Aggregation with fewer than threshold shares should fail");
+        assert!(
+            result.is_err(),
+            "Aggregation with fewer than threshold shares should fail"
+        );
     }
 }

--- a/crates/ochra-crypto/src/groth16.rs
+++ b/crates/ochra-crypto/src/groth16.rs
@@ -10,9 +10,7 @@
 //! - Desktop proving (2^16 constraints): ~3-5s
 
 use ark_bls12_381::{Bls12_381, Fr};
-use ark_groth16::{
-    Groth16, PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey,
-};
+use ark_groth16::{Groth16, PreparedVerifyingKey, Proof, ProvingKey, VerifyingKey};
 use ark_relations::r1cs::{ConstraintSynthesizer, ConstraintSystemRef, SynthesisError};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use ark_snark::SNARK;
@@ -114,7 +112,10 @@ pub struct MultiplyCircuit {
 }
 
 impl ConstraintSynthesizer<Fr> for MultiplyCircuit {
-    fn generate_constraints(self, cs: ConstraintSystemRef<Fr>) -> std::result::Result<(), SynthesisError> {
+    fn generate_constraints(
+        self,
+        cs: ConstraintSystemRef<Fr>,
+    ) -> std::result::Result<(), SynthesisError> {
         let a_val = self.a.unwrap_or(Fr::from(0u64));
         let b_val = self.b.unwrap_or(Fr::from(0u64));
         let c_val = a_val * b_val;

--- a/crates/ochra-crypto/src/pedersen.rs
+++ b/crates/ochra-crypto/src/pedersen.rs
@@ -52,8 +52,7 @@ impl PedersenParams {
             bytes.copy_from_slice(chunk);
             repr[i] = u64::from_le_bytes(bytes);
         }
-        let scalar = Fr::from_bigint(ark_ff::BigInteger256::new(repr))
-            .unwrap_or(Fr::from(1u64));
+        let scalar = Fr::from_bigint(ark_ff::BigInteger256::new(repr)).unwrap_or(Fr::from(1u64));
         let h = g.mul(scalar);
 
         Self { g, h }

--- a/crates/ochra-crypto/src/poseidon.rs
+++ b/crates/ochra-crypto/src/poseidon.rs
@@ -204,7 +204,8 @@ pub fn bytes_to_field(bytes: &[u8; 32]) -> Result<Fr> {
         repr[i] = u64::from_le_bytes(b);
     }
     let big = BigInteger256::new(repr);
-    Fr::from_bigint(big).ok_or_else(|| CryptoError::InvalidInput("value exceeds field modulus".into()))
+    Fr::from_bigint(big)
+        .ok_or_else(|| CryptoError::InvalidInput("value exceeds field modulus".into()))
 }
 
 /// Convert a field element to bytes.
@@ -284,10 +285,7 @@ mod tests {
         assert_eq!(params.width, 3);
         assert_eq!(params.full_rounds, 8);
         assert_eq!(params.partial_rounds, 57);
-        assert_eq!(
-            params.round_constants.len(),
-            (8 + 57) * 3
-        );
+        assert_eq!(params.round_constants.len(), (8 + 57) * 3);
         assert_eq!(params.mds_matrix.len(), 3);
         assert_eq!(params.mds_matrix[0].len(), 3);
     }

--- a/crates/ochra-crypto/src/x25519.rs
+++ b/crates/ochra-crypto/src/x25519.rs
@@ -177,7 +177,10 @@ mod tests {
         let secret = X25519StaticSecret::random();
         let bytes = secret.to_bytes();
         let restored = X25519StaticSecret::from_bytes(bytes);
-        assert_eq!(secret.public_key().to_bytes(), restored.public_key().to_bytes());
+        assert_eq!(
+            secret.public_key().to_bytes(),
+            restored.public_key().to_bytes()
+        );
     }
 
     #[test]
@@ -191,14 +194,12 @@ mod tests {
     #[test]
     fn test_rfc7748_section6_1() {
         // RFC 7748 Section 6.1 test vector
-        let alice_private = hex::decode(
-            "77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
-        )
-        .expect("valid hex");
-        let alice_public = hex::decode(
-            "8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a",
-        )
-        .expect("valid hex");
+        let alice_private =
+            hex::decode("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a")
+                .expect("valid hex");
+        let alice_public =
+            hex::decode("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a")
+                .expect("valid hex");
 
         let mut secret_bytes = [0u8; 32];
         secret_bytes.copy_from_slice(&alice_private);

--- a/crates/ochra-daemon/src/commands/identity.rs
+++ b/crates/ochra-daemon/src/commands/identity.rs
@@ -29,8 +29,13 @@ pub async fn init_pik(state: &Arc<DaemonState>, params: &Value) -> Result {
         .map_err(|e| RpcError::internal_error(&format!("key derivation failed: {e}")))?;
 
     let nonce = [0u8; 12]; // Will use random nonce in production
-    let encrypted_pik = ochra_crypto::chacha20::encrypt(&derived_key, &nonce, keypair.signing_key.to_bytes().as_slice(), &[])
-        .map_err(|e| RpcError::internal_error(&format!("encryption failed: {e}")))?;
+    let encrypted_pik = ochra_crypto::chacha20::encrypt(
+        &derived_key,
+        &nonce,
+        keypair.signing_key.to_bytes().as_slice(),
+        &[],
+    )
+    .map_err(|e| RpcError::internal_error(&format!("encryption failed: {e}")))?;
 
     // Store in database
     {

--- a/crates/ochra-daemon/src/commands/network.rs
+++ b/crates/ochra-daemon/src/commands/network.rs
@@ -275,10 +275,7 @@ pub async fn get_onion_circuit_health(_state: &Arc<DaemonState>) -> Result {
 }
 
 /// Set per-Space notification settings.
-pub async fn set_group_notification_settings(
-    _state: &Arc<DaemonState>,
-    params: &Value,
-) -> Result {
+pub async fn set_group_notification_settings(_state: &Arc<DaemonState>, params: &Value) -> Result {
     let _group_id = params
         .get("group_id")
         .ok_or_else(|| RpcError::invalid_params("group_id required"))?;

--- a/crates/ochra-daemon/src/main.rs
+++ b/crates/ochra-daemon/src/main.rs
@@ -38,8 +38,7 @@ async fn main() -> anyhow::Result<()> {
     // Initialize tracing
     tracing_subscriber::fmt()
         .with_env_filter(
-            tracing_subscriber::EnvFilter::from_default_env()
-                .add_directive("ochra=info".parse()?),
+            tracing_subscriber::EnvFilter::from_default_env().add_directive("ochra=info".parse()?),
         )
         .init();
 

--- a/crates/ochra-daemon/src/rpc.rs
+++ b/crates/ochra-daemon/src/rpc.rs
@@ -246,7 +246,10 @@ async fn dispatch_request(state: Arc<DaemonState>, request: RpcRequest) -> RpcRe
     debug!("Dispatching RPC method: {}", method);
 
     // Check if method requires authentication
-    let requires_auth = !matches!(method, "init_pik" | "authenticate" | "authenticate_biometric");
+    let requires_auth = !matches!(
+        method,
+        "init_pik" | "authenticate" | "authenticate_biometric"
+    );
 
     if requires_auth {
         let unlocked = state.unlocked.read().await;
@@ -254,7 +257,10 @@ async fn dispatch_request(state: Arc<DaemonState>, request: RpcRequest) -> RpcRe
             // Allow some diagnostic commands even when locked
             if !matches!(
                 method,
-                "get_daemon_logs" | "export_diagnostics" | "lock_session" | "check_protocol_updates"
+                "get_daemon_logs"
+                    | "export_diagnostics"
+                    | "lock_session"
+                    | "check_protocol_updates"
             ) {
                 return RpcResponse::error(id, RpcError::session_locked());
             }
@@ -279,9 +285,7 @@ async fn dispatch_request(state: Arc<DaemonState>, request: RpcRequest) -> RpcRe
         "nominate_guardian" => commands::identity::nominate_guardian(&state, &request.params).await,
         "replace_guardian" => commands::identity::replace_guardian(&state, &request.params).await,
         "get_guardian_health" => commands::identity::get_guardian_health(&state).await,
-        "initiate_recovery" => {
-            commands::identity::initiate_recovery(&state, &request.params).await
-        }
+        "initiate_recovery" => commands::identity::initiate_recovery(&state, &request.params).await,
         "veto_recovery" => commands::identity::veto_recovery(&state, &request.params).await,
         "add_contact" => commands::identity::add_contact(&state, &request.params).await,
         "remove_contact" => commands::identity::remove_contact(&state, &request.params).await,
@@ -298,7 +302,9 @@ async fn dispatch_request(state: Arc<DaemonState>, request: RpcRequest) -> RpcRe
         "kick_member" => commands::network::kick_member(&state, &request.params).await,
         "generate_invite" => commands::network::generate_invite(&state, &request.params).await,
         "revoke_invite" => commands::network::revoke_invite(&state, &request.params).await,
-        "get_active_invites" => commands::network::get_active_invites(&state, &request.params).await,
+        "get_active_invites" => {
+            commands::network::get_active_invites(&state, &request.params).await
+        }
         "get_group_members" => commands::network::get_group_members(&state, &request.params).await,
         "grant_publisher_role" => {
             commands::network::grant_publisher_role(&state, &request.params).await
@@ -395,9 +401,7 @@ async fn dispatch_request(state: Arc<DaemonState>, request: RpcRequest) -> RpcRe
             commands::file_io::redownload_content(&state, &request.params).await
         }
         "get_purchase_receipts" => commands::file_io::get_purchase_receipts(&state).await,
-        "get_access_status" => {
-            commands::file_io::get_access_status(&state, &request.params).await
-        }
+        "get_access_status" => commands::file_io::get_access_status(&state, &request.params).await,
         "download_file" => commands::file_io::download_file(&state, &request.params).await,
         "pause_download" => commands::file_io::pause_download(&state, &request.params).await,
         "get_abr_telemetry" => commands::file_io::get_abr_telemetry(&state).await,
@@ -447,13 +451,17 @@ async fn dispatch_request(state: Arc<DaemonState>, request: RpcRequest) -> RpcRe
         "lock_session" => commands::diagnostics::lock_session(&state).await,
 
         // Event subscription (Section 21.7)
-        "subscribe_events" => commands::diagnostics::subscribe_events(&state, &request.params).await,
+        "subscribe_events" => {
+            commands::diagnostics::subscribe_events(&state, &request.params).await
+        }
         "unsubscribe_events" => {
             commands::diagnostics::unsubscribe_events(&state, &request.params).await
         }
 
         // Dev-only commands
-        "dev_set_oracle_rate" => commands::economy::dev_set_oracle_rate(&state, &request.params).await,
+        "dev_set_oracle_rate" => {
+            commands::economy::dev_set_oracle_rate(&state, &request.params).await
+        }
 
         _ => Err(RpcError::method_not_found(method)),
     };
@@ -483,20 +491,14 @@ mod tests {
 
     #[test]
     fn test_rpc_response_success() {
-        let resp = RpcResponse::success(
-            serde_json::json!(1),
-            serde_json::json!({"balance": 1000}),
-        );
+        let resp = RpcResponse::success(serde_json::json!(1), serde_json::json!({"balance": 1000}));
         assert!(resp.result.is_some());
         assert!(resp.error.is_none());
     }
 
     #[test]
     fn test_rpc_response_error() {
-        let resp = RpcResponse::error(
-            serde_json::json!(1),
-            RpcError::internal_error("test"),
-        );
+        let resp = RpcResponse::error(serde_json::json!(1), RpcError::internal_error("test"));
         assert!(resp.result.is_none());
         assert!(resp.error.is_some());
     }

--- a/crates/ochra-db/src/migrations.rs
+++ b/crates/ochra-db/src/migrations.rs
@@ -85,7 +85,8 @@ mod tests {
     #[test]
     fn test_fresh_migration() {
         let conn = Connection::open_in_memory().expect("open");
-        conn.execute_batch("PRAGMA foreign_keys = ON;").expect("pragma");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("pragma");
         run(&conn).expect("migrate");
 
         let version: u32 = conn
@@ -97,7 +98,8 @@ mod tests {
     #[test]
     fn test_idempotent_migration() {
         let conn = Connection::open_in_memory().expect("open");
-        conn.execute_batch("PRAGMA foreign_keys = ON;").expect("pragma");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("pragma");
         run(&conn).expect("first run");
         run(&conn).expect("second run should be no-op");
     }
@@ -105,7 +107,8 @@ mod tests {
     #[test]
     fn test_default_settings() {
         let conn = Connection::open_in_memory().expect("open");
-        conn.execute_batch("PRAGMA foreign_keys = ON;").expect("pragma");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("pragma");
         run(&conn).expect("migrate");
 
         let theme: String = conn
@@ -121,7 +124,8 @@ mod tests {
     #[test]
     fn test_tables_created() {
         let conn = Connection::open_in_memory().expect("open");
-        conn.execute_batch("PRAGMA foreign_keys = ON;").expect("pragma");
+        conn.execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("pragma");
         run(&conn).expect("migrate");
 
         let expected_tables = [

--- a/crates/ochra-db/src/queries/contacts.rs
+++ b/crates/ochra-db/src/queries/contacts.rs
@@ -43,9 +43,7 @@ pub fn get(conn: &Connection, pik_hash: &[u8; 32]) -> Result<ContactRow> {
         },
     )
     .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => {
-            DbError::NotFound("contact".into())
-        }
+        rusqlite::Error::QueryReturnedNoRows => DbError::NotFound("contact".into()),
         other => DbError::Sqlite(other),
     })
 }

--- a/crates/ochra-db/src/queries/content.rs
+++ b/crates/ochra-db/src/queries/content.rs
@@ -99,8 +99,16 @@ mod tests {
     fn test_db() -> Connection {
         let conn = crate::open_memory().expect("open test db");
         // Insert a space first (foreign key)
-        spaces::insert(&conn, &[1u8; 32], "Test", "storefront", "host", &[2u8; 32], 1000)
-            .expect("insert space");
+        spaces::insert(
+            &conn,
+            &[1u8; 32],
+            "Test",
+            "storefront",
+            "host",
+            &[2u8; 32],
+            1000,
+        )
+        .expect("insert space");
         conn
     }
 

--- a/crates/ochra-db/src/queries/settings.rs
+++ b/crates/ochra-db/src/queries/settings.rs
@@ -6,15 +6,11 @@ use crate::{DbError, Result};
 
 /// Get a setting value by key.
 pub fn get(conn: &Connection, key: &str) -> Result<String> {
-    conn.query_row(
-        "SELECT value FROM settings WHERE key = ?1",
-        [key],
-        |row| row.get(0),
-    )
+    conn.query_row("SELECT value FROM settings WHERE key = ?1", [key], |row| {
+        row.get(0)
+    })
     .map_err(|e| match e {
-        rusqlite::Error::QueryReturnedNoRows => {
-            DbError::NotFound(format!("setting '{key}'"))
-        }
+        rusqlite::Error::QueryReturnedNoRows => DbError::NotFound(format!("setting '{key}'")),
         other => DbError::Sqlite(other),
     })
 }

--- a/crates/ochra-db/src/queries/spaces.rs
+++ b/crates/ochra-db/src/queries/spaces.rs
@@ -85,8 +85,16 @@ mod tests {
     #[test]
     fn test_insert_and_list() {
         let conn = test_db();
-        insert(&conn, &[1u8; 32], "Test Space", "storefront", "host", &[2u8; 32], 1000)
-            .expect("insert");
+        insert(
+            &conn,
+            &[1u8; 32],
+            "Test Space",
+            "storefront",
+            "host",
+            &[2u8; 32],
+            1000,
+        )
+        .expect("insert");
 
         let spaces = list(&conn).expect("list");
         assert_eq!(spaces.len(), 1);
@@ -98,8 +106,10 @@ mod tests {
     #[test]
     fn test_pin_space() {
         let conn = test_db();
-        insert(&conn, &[1u8; 32], "Space A", "forum", "member", &[2u8; 32], 1000)
-            .expect("insert");
+        insert(
+            &conn, &[1u8; 32], "Space A", "forum", "member", &[2u8; 32], 1000,
+        )
+        .expect("insert");
 
         set_pinned(&conn, &[1u8; 32], true).expect("pin");
         let spaces = list(&conn).expect("list");

--- a/crates/ochra-dht/src/bep44.rs
+++ b/crates/ochra-dht/src/bep44.rs
@@ -13,7 +13,6 @@
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-
 use crate::{DhtError, Result, MAX_RECORD_SIZE};
 
 /// Default record time-to-live (2 hours).
@@ -338,13 +337,9 @@ mod tests {
     #[test]
     fn test_mutable_record_roundtrip() {
         let kp = KeyPair::generate();
-        let record = create_mutable_record(
-            &kp.signing_key,
-            b"test-salt",
-            1,
-            b"mutable data".to_vec(),
-        )
-        .expect("create record");
+        let record =
+            create_mutable_record(&kp.signing_key, b"test-salt", 1, b"mutable data".to_vec())
+                .expect("create record");
 
         assert!(record.validate().is_ok());
     }
@@ -352,13 +347,8 @@ mod tests {
     #[test]
     fn test_mutable_record_wrong_signature() {
         let kp = KeyPair::generate();
-        let mut record = create_mutable_record(
-            &kp.signing_key,
-            b"salt",
-            1,
-            b"data".to_vec(),
-        )
-        .expect("create record");
+        let mut record = create_mutable_record(&kp.signing_key, b"salt", 1, b"data".to_vec())
+            .expect("create record");
 
         // Tamper with the value
         if let DhtRecord::Mutable { ref mut value, .. } = record {
@@ -372,13 +362,8 @@ mod tests {
     fn test_mutable_record_storage_key() {
         let kp = KeyPair::generate();
         let salt = b"my-salt";
-        let record = create_mutable_record(
-            &kp.signing_key,
-            salt,
-            1,
-            b"value".to_vec(),
-        )
-        .expect("create record");
+        let record = create_mutable_record(&kp.signing_key, salt, 1, b"value".to_vec())
+            .expect("create record");
 
         let expected_key = {
             let mut input = Vec::new();
@@ -412,12 +397,10 @@ mod tests {
         let mut store = RecordStore::new();
         let kp = KeyPair::generate();
 
-        let r1 = create_mutable_record(&kp.signing_key, b"s", 1, b"v1".to_vec())
-            .expect("create");
-        let r2 = create_mutable_record(&kp.signing_key, b"s", 2, b"v2".to_vec())
-            .expect("create");
-        let r_stale = create_mutable_record(&kp.signing_key, b"s", 1, b"v_stale".to_vec())
-            .expect("create");
+        let r1 = create_mutable_record(&kp.signing_key, b"s", 1, b"v1".to_vec()).expect("create");
+        let r2 = create_mutable_record(&kp.signing_key, b"s", 2, b"v2".to_vec()).expect("create");
+        let r_stale =
+            create_mutable_record(&kp.signing_key, b"s", 1, b"v_stale".to_vec()).expect("create");
 
         store.put(r1).expect("put r1");
         store.put(r2).expect("put r2");
@@ -425,7 +408,10 @@ mod tests {
         // Stale sequence should be rejected
         let result = store.put(r_stale);
         assert!(result.is_err());
-        assert!(matches!(result, Err(DhtError::StaleSequence { got: 1, have: 2 })));
+        assert!(matches!(
+            result,
+            Err(DhtError::StaleSequence { got: 1, have: 2 })
+        ));
     }
 
     #[test]

--- a/crates/ochra-dht/src/bootstrap.rs
+++ b/crates/ochra-dht/src/bootstrap.rs
@@ -218,7 +218,9 @@ pub trait BootstrapTransport {
         &self,
         addr: SocketAddr,
         timeout: Duration,
-    ) -> impl std::future::Future<Output = std::result::Result<NodeInfo, Box<dyn std::error::Error + Send + Sync>>> + Send;
+    ) -> impl std::future::Future<
+        Output = std::result::Result<NodeInfo, Box<dyn std::error::Error + Send + Sync>>,
+    > + Send;
 
     /// Perform a `FIND_NODE` query against the given nodes.
     ///
@@ -228,7 +230,9 @@ pub trait BootstrapTransport {
         target: NodeId,
         initial_nodes: Vec<NodeInfo>,
         timeout: Duration,
-    ) -> impl std::future::Future<Output = std::result::Result<Vec<NodeInfo>, Box<dyn std::error::Error + Send + Sync>>> + Send;
+    ) -> impl std::future::Future<
+        Output = std::result::Result<Vec<NodeInfo>, Box<dyn std::error::Error + Send + Sync>>,
+    > + Send;
 }
 
 /// Serde support for SocketAddr as a string.

--- a/crates/ochra-dht/src/chunking.rs
+++ b/crates/ochra-dht/src/chunking.rs
@@ -115,10 +115,7 @@ pub fn build_manifest(chunks: &[Chunk], total_size: u64) -> ChunkManifest {
 /// Returns [`DhtError::MissingChunk`] if any chunk is missing.
 /// Returns [`DhtError::Serialization`] if a chunk's data hash does not match
 /// the manifest.
-pub fn assemble_record(
-    manifest: &ChunkManifest,
-    chunks: &[Chunk],
-) -> Result<Vec<u8>> {
+pub fn assemble_record(manifest: &ChunkManifest, chunks: &[Chunk]) -> Result<Vec<u8>> {
     // Sort chunks by index.
     let mut sorted_chunks = chunks.to_vec();
     sorted_chunks.sort_by_key(|c| c.index);
@@ -260,10 +257,7 @@ mod tests {
         let manifest = build_manifest(&chunks, value.len() as u64);
 
         // Remove the middle chunk
-        let partial: Vec<Chunk> = chunks
-            .into_iter()
-            .filter(|c| c.index != 1)
-            .collect();
+        let partial: Vec<Chunk> = chunks.into_iter().filter(|c| c.index != 1).collect();
 
         let result = assemble_record(&manifest, &partial);
         assert!(result.is_err());
@@ -302,9 +296,6 @@ mod tests {
         assert_eq!(manifest.total_chunks, 1);
         assert_eq!(manifest.total_size, value.len() as u64);
         assert_eq!(manifest.chunk_hashes.len(), 1);
-        assert_eq!(
-            manifest.chunk_hashes[0],
-            ochra_crypto::blake3::hash(value)
-        );
+        assert_eq!(manifest.chunk_hashes[0], ochra_crypto::blake3::hash(value));
     }
 }

--- a/crates/ochra-dht/src/kademlia.rs
+++ b/crates/ochra-dht/src/kademlia.rs
@@ -212,14 +212,8 @@ impl RoutingTable {
     /// and insert `new_node` in its place.
     ///
     /// Call this after a failed ping to the LRS node returned by [`add_node`].
-    pub fn evict_and_insert(
-        &mut self,
-        stale_id: &NodeId,
-        new_node: NodeInfo,
-    ) -> Result<()> {
-        let bucket_idx = self
-            .bucket_index(stale_id)
-            .ok_or(DhtError::BucketFull)?;
+    pub fn evict_and_insert(&mut self, stale_id: &NodeId, new_node: NodeInfo) -> Result<()> {
+        let bucket_idx = self.bucket_index(stale_id).ok_or(DhtError::BucketFull)?;
 
         let bucket = &mut self.buckets[bucket_idx];
 
@@ -290,8 +284,7 @@ impl RoutingTable {
             .iter()
             .enumerate()
             .filter(|(_, b)| {
-                !b.entries.is_empty()
-                    && now.duration_since(b.last_refresh) > refresh_interval
+                !b.entries.is_empty() && now.duration_since(b.last_refresh) > refresh_interval
             })
             .map(|(i, _)| i)
             .collect()
@@ -406,7 +399,11 @@ impl FindNodeLookup {
             if self.queried.contains(&info.node_id) {
                 continue;
             }
-            if self.candidates.iter().any(|c| c.info.node_id == info.node_id) {
+            if self
+                .candidates
+                .iter()
+                .any(|c| c.info.node_id == info.node_id)
+            {
                 continue;
             }
 

--- a/crates/ochra-frost/src/dkg.rs
+++ b/crates/ochra-frost/src/dkg.rs
@@ -104,10 +104,7 @@ pub struct DkgCeremony {
 /// # Returns
 ///
 /// A new [`DkgCeremony`] in Round 1.
-pub fn start_ceremony(
-    participants: Vec<[u8; 32]>,
-    threshold: u16,
-) -> Result<DkgCeremony> {
+pub fn start_ceremony(participants: Vec<[u8; 32]>, threshold: u16) -> Result<DkgCeremony> {
     if participants.is_empty() {
         return Err(FrostCoordError::Quorum(
             "no participants provided".to_string(),
@@ -176,15 +173,18 @@ impl DkgCeremony {
         }
 
         if !self.participants.contains(&commitment.participant_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(commitment.participant_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                commitment.participant_id,
+            )));
         }
 
-        if self.round1_commitments.contains_key(&commitment.participant_id) {
-            return Err(FrostCoordError::DuplicateContribution(
-                hex::encode(commitment.participant_id),
-            ));
+        if self
+            .round1_commitments
+            .contains_key(&commitment.participant_id)
+        {
+            return Err(FrostCoordError::DuplicateContribution(hex::encode(
+                commitment.participant_id,
+            )));
         }
 
         let pid = commitment.participant_id;
@@ -193,7 +193,11 @@ impl DkgCeremony {
         tracing::debug!(
             ceremony_id = hex::encode(self.ceremony_id),
             participant = hex::encode(pid),
-            progress = format!("{}/{}", self.round1_commitments.len(), self.participants.len()),
+            progress = format!(
+                "{}/{}",
+                self.round1_commitments.len(),
+                self.participants.len()
+            ),
             "received Round 1 commitment"
         );
 
@@ -222,15 +226,15 @@ impl DkgCeremony {
         }
 
         if !self.participants.contains(&share_package.sender_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(share_package.sender_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                share_package.sender_id,
+            )));
         }
 
         if !self.participants.contains(&share_package.recipient_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(share_package.recipient_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                share_package.recipient_id,
+            )));
         }
 
         let sender = share_package.sender_id;
@@ -278,15 +282,18 @@ impl DkgCeremony {
         }
 
         if !self.participants.contains(&verification.participant_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(verification.participant_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                verification.participant_id,
+            )));
         }
 
-        if self.round3_verifications.contains_key(&verification.participant_id) {
-            return Err(FrostCoordError::DuplicateContribution(
-                hex::encode(verification.participant_id),
-            ));
+        if self
+            .round3_verifications
+            .contains_key(&verification.participant_id)
+        {
+            return Err(FrostCoordError::DuplicateContribution(hex::encode(
+                verification.participant_id,
+            )));
         }
 
         if !verification.verified {
@@ -303,7 +310,11 @@ impl DkgCeremony {
         tracing::debug!(
             ceremony_id = hex::encode(self.ceremony_id),
             participant = hex::encode(pid),
-            progress = format!("{}/{}", self.round3_verifications.len(), self.participants.len()),
+            progress = format!(
+                "{}/{}",
+                self.round3_verifications.len(),
+                self.participants.len()
+            ),
             "received Round 3 verification"
         );
 
@@ -324,10 +335,7 @@ impl DkgCeremony {
     /// Only valid after the ceremony is complete.
     pub fn all_verified(&self) -> bool {
         self.round == CeremonyRound::Complete
-            && self
-                .round3_verifications
-                .values()
-                .all(|v| v.verified)
+            && self.round3_verifications.values().all(|v| v.verified)
     }
 
     /// Get the Round 1 commitments (available after Round 1 completes).

--- a/crates/ochra-frost/src/quorum.rs
+++ b/crates/ochra-frost/src/quorum.rs
@@ -28,11 +28,7 @@ impl QuorumConfig {
     /// * `threshold` - Minimum signers required.
     /// * `members` - Initial quorum member node IDs.
     /// * `max_churn_per_epoch` - Maximum membership changes per epoch.
-    pub fn new(
-        threshold: u16,
-        members: Vec<[u8; 32]>,
-        max_churn_per_epoch: usize,
-    ) -> Result<Self> {
+    pub fn new(threshold: u16, members: Vec<[u8; 32]>, max_churn_per_epoch: usize) -> Result<Self> {
         if threshold == 0 || threshold as usize > members.len() {
             return Err(FrostCoordError::Quorum(format!(
                 "invalid threshold {threshold} for {} members",
@@ -105,7 +101,11 @@ pub fn select_quorum(
             .then_with(|| a.node_id.cmp(&b.node_id))
     });
 
-    let selected: Vec<[u8; 32]> = sorted.iter().take(required_size).map(|n| n.node_id).collect();
+    let selected: Vec<[u8; 32]> = sorted
+        .iter()
+        .take(required_size)
+        .map(|n| n.node_id)
+        .collect();
 
     tracing::debug!(
         selected = selected.len(),
@@ -132,8 +132,7 @@ pub fn select_quorum(
 pub fn can_rotate(current: &QuorumConfig, proposed: &[[u8; 32]]) -> bool {
     let current_set: std::collections::HashSet<[u8; 32]> =
         current.members.iter().copied().collect();
-    let proposed_set: std::collections::HashSet<[u8; 32]> =
-        proposed.iter().copied().collect();
+    let proposed_set: std::collections::HashSet<[u8; 32]> = proposed.iter().copied().collect();
 
     let added = proposed_set.difference(&current_set).count();
     let removed = current_set.difference(&proposed_set).count();
@@ -150,8 +149,7 @@ pub fn can_rotate(current: &QuorumConfig, proposed: &[[u8; 32]]) -> bool {
 pub fn compute_churn(current: &QuorumConfig, proposed: &[[u8; 32]]) -> (usize, usize) {
     let current_set: std::collections::HashSet<[u8; 32]> =
         current.members.iter().copied().collect();
-    let proposed_set: std::collections::HashSet<[u8; 32]> =
-        proposed.iter().copied().collect();
+    let proposed_set: std::collections::HashSet<[u8; 32]> = proposed.iter().copied().collect();
 
     let added = proposed_set.difference(&current_set).count();
     let removed = current_set.difference(&proposed_set).count();

--- a/crates/ochra-frost/src/reshare.rs
+++ b/crates/ochra-frost/src/reshare.rs
@@ -114,14 +114,10 @@ pub fn initiate_reshare(
     new_threshold: u16,
 ) -> Result<ReshareCeremony> {
     if old_quorum.is_empty() {
-        return Err(FrostCoordError::Reshare(
-            "old quorum is empty".to_string(),
-        ));
+        return Err(FrostCoordError::Reshare("old quorum is empty".to_string()));
     }
     if new_quorum.is_empty() {
-        return Err(FrostCoordError::Reshare(
-            "new quorum is empty".to_string(),
-        ));
+        return Err(FrostCoordError::Reshare("new quorum is empty".to_string()));
     }
     if new_threshold == 0 || new_threshold as usize > new_quorum.len() {
         return Err(FrostCoordError::Reshare(format!(
@@ -199,15 +195,15 @@ impl ReshareCeremony {
         }
 
         if !self.old_quorum.contains(&commitment.participant_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(commitment.participant_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                commitment.participant_id,
+            )));
         }
 
         if self.commitments.contains_key(&commitment.participant_id) {
-            return Err(FrostCoordError::DuplicateContribution(
-                hex::encode(commitment.participant_id),
-            ));
+            return Err(FrostCoordError::DuplicateContribution(hex::encode(
+                commitment.participant_id,
+            )));
         }
 
         let pid = commitment.participant_id;
@@ -234,22 +230,19 @@ impl ReshareCeremony {
         }
 
         if !self.old_quorum.contains(&package.sender_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(package.sender_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                package.sender_id,
+            )));
         }
 
         if !self.new_quorum.contains(&package.recipient_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(package.recipient_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                package.recipient_id,
+            )));
         }
 
         let sender = package.sender_id;
-        self.distributions
-            .entry(sender)
-            .or_default()
-            .push(package);
+        self.distributions.entry(sender).or_default().push(package);
 
         // Advance to Phase 3 when all old quorum members have distributed
         // shares to all new quorum members.
@@ -280,15 +273,18 @@ impl ReshareCeremony {
         }
 
         if !self.new_quorum.contains(&verification.participant_id) {
-            return Err(FrostCoordError::UnknownSigner(
-                hex::encode(verification.participant_id),
-            ));
+            return Err(FrostCoordError::UnknownSigner(hex::encode(
+                verification.participant_id,
+            )));
         }
 
-        if self.verifications.contains_key(&verification.participant_id) {
-            return Err(FrostCoordError::DuplicateContribution(
-                hex::encode(verification.participant_id),
-            ));
+        if self
+            .verifications
+            .contains_key(&verification.participant_id)
+        {
+            return Err(FrostCoordError::DuplicateContribution(hex::encode(
+                verification.participant_id,
+            )));
         }
 
         let pid = verification.participant_id;

--- a/crates/ochra-frost/src/roast.rs
+++ b/crates/ochra-frost/src/roast.rs
@@ -150,12 +150,13 @@ impl RoastSession {
 
     /// Mark an attempt as ready to collect shares (commitments phase done).
     pub fn advance_to_shares(&mut self, attempt_index: usize) -> Result<()> {
-        let attempt = self.attempts.get_mut(attempt_index).ok_or_else(|| {
-            FrostCoordError::InvalidState {
-                expected: format!("attempt {attempt_index} exists"),
-                actual: "attempt not found".to_string(),
-            }
-        })?;
+        let attempt =
+            self.attempts
+                .get_mut(attempt_index)
+                .ok_or_else(|| FrostCoordError::InvalidState {
+                    expected: format!("attempt {attempt_index} exists"),
+                    actual: "attempt not found".to_string(),
+                })?;
 
         if attempt.state != SessionState::CollectingCommitments {
             return Err(FrostCoordError::InvalidState {
@@ -224,10 +225,7 @@ impl RoastSession {
             let sig = self.aggregate_shares(attempt_idx)?;
             self.final_signature = Some(sig.clone());
 
-            tracing::info!(
-                attempt = attempt_idx,
-                "ROAST session complete"
-            );
+            tracing::info!(attempt = attempt_idx, "ROAST session complete");
 
             return Ok(Some(sig));
         }
@@ -283,12 +281,13 @@ impl RoastSession {
     /// This v1 implementation hashes all shares together as a placeholder.
     /// A real implementation would call `ochra_crypto::frost::aggregate`.
     fn aggregate_shares(&self, attempt_index: usize) -> Result<Vec<u8>> {
-        let attempt = self.attempts.get(attempt_index).ok_or_else(|| {
-            FrostCoordError::InvalidState {
-                expected: format!("attempt {attempt_index} exists"),
-                actual: "attempt not found".to_string(),
-            }
-        })?;
+        let attempt =
+            self.attempts
+                .get(attempt_index)
+                .ok_or_else(|| FrostCoordError::InvalidState {
+                    expected: format!("attempt {attempt_index} exists"),
+                    actual: "attempt not found".to_string(),
+                })?;
 
         // Placeholder aggregation: hash all shares together.
         let mut all_share_data = Vec::new();
@@ -339,9 +338,8 @@ mod tests {
 
     #[test]
     fn test_complete_signing_session() {
-        let mut session =
-            RoastSession::start_signing(b"test message".to_vec(), make_signers(5), 3)
-                .expect("start");
+        let mut session = RoastSession::start_signing(b"test message".to_vec(), make_signers(5), 3)
+            .expect("start");
 
         let idx = session.new_attempt().expect("attempt");
         session.advance_to_shares(idx).expect("advance");

--- a/crates/ochra-guardian/src/dkg.rs
+++ b/crates/ochra-guardian/src/dkg.rs
@@ -61,10 +61,7 @@ pub struct GuardianDkg {
 /// - [`GuardianError::TooFewGuardians`] if fewer than `threshold` guardians
 /// - [`GuardianError::DkgError`] if threshold is zero
 /// - [`GuardianError::DkgError`] if threshold exceeds the number of guardians
-pub fn initiate_dkg(
-    guardians: Vec<GuardianInfo>,
-    threshold: u32,
-) -> Result<GuardianDkg> {
+pub fn initiate_dkg(guardians: Vec<GuardianInfo>, threshold: u32) -> Result<GuardianDkg> {
     if threshold == 0 {
         return Err(GuardianError::DkgError(
             "threshold must be at least 1".to_string(),
@@ -134,10 +131,7 @@ impl GuardianDkg {
 
         self.status = DkgStatus::SharesDistributed;
 
-        tracing::info!(
-            shares = self.shares.len(),
-            "DKG shares distributed"
-        );
+        tracing::info!(shares = self.shares.len(), "DKG shares distributed");
 
         // In a real implementation, guardians would verify and acknowledge.
         // For v1, we mark as complete immediately.

--- a/crates/ochra-guardian/src/heartbeat.rs
+++ b/crates/ochra-guardian/src/heartbeat.rs
@@ -63,10 +63,7 @@ pub fn publish_heartbeat(guardian_id: [u8; 32], timestamp: u64) -> Heartbeat {
     // Stub signature in v1
     let signature = [0u8; 64];
 
-    tracing::debug!(
-        timestamp,
-        "guardian heartbeat published"
-    );
+    tracing::debug!(timestamp, "guardian heartbeat published");
 
     Heartbeat {
         guardian_id,
@@ -120,31 +117,19 @@ mod tests {
 
     #[test]
     fn test_check_heartbeat_healthy() {
-        let status = check_heartbeat(
-            &[0x01; 32],
-            1_000_000,
-            1_000_000 + WARNING_AGE - 1,
-        );
+        let status = check_heartbeat(&[0x01; 32], 1_000_000, 1_000_000 + WARNING_AGE - 1);
         assert_eq!(status, HealthStatus::Healthy);
     }
 
     #[test]
     fn test_check_heartbeat_warning() {
-        let status = check_heartbeat(
-            &[0x01; 32],
-            1_000_000,
-            1_000_000 + WARNING_AGE + 1,
-        );
+        let status = check_heartbeat(&[0x01; 32], 1_000_000, 1_000_000 + WARNING_AGE + 1);
         assert_eq!(status, HealthStatus::Warning);
     }
 
     #[test]
     fn test_check_heartbeat_unresponsive() {
-        let status = check_heartbeat(
-            &[0x01; 32],
-            1_000_000,
-            1_000_000 + MAX_HEARTBEAT_AGE + 1,
-        );
+        let status = check_heartbeat(&[0x01; 32], 1_000_000, 1_000_000 + MAX_HEARTBEAT_AGE + 1);
         assert_eq!(status, HealthStatus::Unresponsive);
     }
 

--- a/crates/ochra-guardian/src/recovery.rs
+++ b/crates/ochra-guardian/src/recovery.rs
@@ -57,10 +57,7 @@ pub struct GuardianShare {
 ///
 /// * `requester_proof` - Proof of identity (stub in v1)
 /// * `current_time` - The current Unix timestamp in seconds
-pub fn initiate_recovery(
-    requester_proof: Vec<u8>,
-    current_time: u64,
-) -> RecoveryRequest {
+pub fn initiate_recovery(requester_proof: Vec<u8>, current_time: u64) -> RecoveryRequest {
     tracing::info!(
         initiated_at = current_time,
         veto_expires = current_time + VETO_WINDOW,

--- a/crates/ochra-guardian/src/replacement.rs
+++ b/crates/ochra-guardian/src/replacement.rs
@@ -60,7 +60,10 @@ pub fn replace_guardian(
         .ok_or_else(|| GuardianError::NotFound(hex::encode(old_id)))?;
 
     // Check the new guardian is not already enrolled
-    if guardians.iter().any(|g| g.pik_hash == new_guardian.pik_hash) {
+    if guardians
+        .iter()
+        .any(|g| g.pik_hash == new_guardian.pik_hash)
+    {
         return Err(GuardianError::AlreadyEnrolled(hex::encode(
             new_guardian.pik_hash,
         )));
@@ -98,11 +101,7 @@ mod tests {
 
     #[test]
     fn test_replace_guardian() {
-        let mut guardians = vec![
-            make_guardian(1),
-            make_guardian(2),
-            make_guardian(3),
-        ];
+        let mut guardians = vec![make_guardian(1), make_guardian(2), make_guardian(3)];
 
         let new_guardian = make_guardian(4);
         let result = replace_guardian(&[2; 32], new_guardian, &mut guardians).expect("replace");
@@ -135,11 +134,7 @@ mod tests {
 
     #[test]
     fn test_replace_preserves_order() {
-        let mut guardians = vec![
-            make_guardian(1),
-            make_guardian(2),
-            make_guardian(3),
-        ];
+        let mut guardians = vec![make_guardian(1), make_guardian(2), make_guardian(3)];
 
         let new_guardian = make_guardian(10);
         replace_guardian(&[2; 32], new_guardian, &mut guardians).expect("replace");

--- a/crates/ochra-integration-tests/tests/circuit_rotation.rs
+++ b/crates/ochra-integration-tests/tests/circuit_rotation.rs
@@ -26,13 +26,7 @@ use ochra_onion::{CIRCUIT_HOPS, CIRCUIT_LIFETIME_SECS, SPHINX_PACKET_SIZE};
 use ochra_types::network::RelayDescriptor;
 
 /// Create a relay descriptor with unique identity and network properties.
-fn make_relay(
-    id_byte: u8,
-    ip: &str,
-    as_num: u32,
-    country: [u8; 2],
-    score: f32,
-) -> RelayDescriptor {
+fn make_relay(id_byte: u8, ip: &str, as_num: u32, country: [u8; 2], score: f32) -> RelayDescriptor {
     let secret = x25519::X25519StaticSecret::random();
     let pk = secret.public_key();
     RelayDescriptor {
@@ -153,11 +147,7 @@ async fn circuit_construction_three_hops() {
     // Step 5: Verify circuit identity
     // =========================================================
     let circuit_id = circuit.circuit_id();
-    assert_eq!(
-        circuit_id.len(),
-        16,
-        "Circuit ID must be 16 bytes"
-    );
+    assert_eq!(circuit_id.len(), 16, "Circuit ID must be 16 bytes");
 
     // Circuit IDs should be unique between circuits.
     let (r1b, _) = make_relay_with_dh(4);
@@ -247,10 +237,7 @@ async fn circuit_builder_error_handling() {
     // Too few relays.
     let (r1b, _) = make_relay_with_dh(5);
 
-    let result2 = CircuitBuilder::new()
-        .add_relay(r1b)
-        .expect("add")
-        .build();
+    let result2 = CircuitBuilder::new().add_relay(r1b).expect("add").build();
 
     assert!(
         result2.is_err(),
@@ -337,7 +324,13 @@ async fn relay_selection_with_constraints() {
     let subnets: HashSet<String> = selected
         .iter()
         .map(|r| {
-            let parts: Vec<&str> = r.ip_addr.split(':').next().unwrap_or("").split('.').collect();
+            let parts: Vec<&str> = r
+                .ip_addr
+                .split(':')
+                .next()
+                .unwrap_or("")
+                .split('.')
+                .collect();
             format!("{}.{}.{}", parts[0], parts[1], parts[2])
         })
         .collect();
@@ -661,7 +654,10 @@ async fn circuit_rotation_readiness() {
 
     assert!(!circuit::needs_rotation(&circuit));
     assert!(!circuit.is_expired());
-    assert!(circuit.age_secs() < 5, "Fresh circuit should be < 5 seconds old");
+    assert!(
+        circuit.age_secs() < 5,
+        "Fresh circuit should be < 5 seconds old"
+    );
     assert!(
         circuit.remaining_secs() > CIRCUIT_LIFETIME_SECS - 5,
         "Fresh circuit should have nearly full lifetime remaining"

--- a/crates/ochra-integration-tests/tests/full_loop.rs
+++ b/crates/ochra-integration-tests/tests/full_loop.rs
@@ -52,9 +52,8 @@ async fn full_lifecycle_identity_to_economy() {
     // =========================================================
     let salt = argon2id::generate_salt();
     // Use small Argon2id params for test speed (production uses 256MB).
-    let encryption_key =
-        argon2id::derive_key_custom(TEST_PASSWORD, &salt, 1024, 1, 1, 32)
-            .expect("Argon2id key derivation should succeed");
+    let encryption_key = argon2id::derive_key_custom(TEST_PASSWORD, &salt, 1024, 1, 1, 32)
+        .expect("Argon2id key derivation should succeed");
     let mut enc_key_arr = [0u8; 32];
     enc_key_arr.copy_from_slice(&encryption_key);
 
@@ -149,8 +148,7 @@ async fn full_lifecycle_identity_to_economy() {
     );
 
     // Verify Merkle root is deterministic.
-    let split_result_2 =
-        chunker::split_content(content_data).expect("Second split should succeed");
+    let split_result_2 = chunker::split_content(content_data).expect("Second split should succeed");
     assert_eq!(
         split_result.content_hash, split_result_2.content_hash,
         "Merkle root must be deterministic for identical content"
@@ -161,12 +159,7 @@ async fn full_lifecycle_identity_to_economy() {
         let proof = chunker::generate_merkle_proof(&split_result.leaf_hashes, i)
             .expect("Merkle proof generation should succeed");
         assert!(
-            chunker::verify_merkle_proof(
-                &split_result.content_hash,
-                leaf_hash,
-                &proof,
-                i as u32,
-            ),
+            chunker::verify_merkle_proof(&split_result.content_hash, leaf_hash, &proof, i as u32,),
             "Merkle proof for chunk {i} must verify against root"
         );
     }
@@ -217,8 +210,7 @@ async fn full_lifecycle_identity_to_economy() {
     .expect("Content catalog insertion should succeed");
 
     // Verify the content appears in the catalog.
-    let catalog = content::list_by_space(&conn, &group_id)
-        .expect("Catalog listing should succeed");
+    let catalog = content::list_by_space(&conn, &group_id).expect("Catalog listing should succeed");
     assert_eq!(catalog.len(), 1, "Catalog should contain one item");
     assert_eq!(catalog[0].title, "Premium Content");
     assert_eq!(catalog[0].total_size_bytes, content_data.len() as u64);
@@ -255,8 +247,7 @@ async fn full_lifecycle_identity_to_economy() {
         creator_pct: 70,
         network_pct: 20,
     };
-    splits::validate_split(&split_config)
-        .expect("Default split configuration must be valid");
+    splits::validate_split(&split_config).expect("Default split configuration must be valid");
 
     let (host_share, creator_share, network_share) =
         splits::distribute(CONTENT_PRICE_MICRO, &split_config)
@@ -308,8 +299,8 @@ async fn full_lifecycle_identity_to_economy() {
     );
 
     // Verify transaction history.
-    let txs = wallet::recent_transactions(&conn, 10)
-        .expect("Transaction history query should succeed");
+    let txs =
+        wallet::recent_transactions(&conn, 10).expect("Transaction history query should succeed");
     assert_eq!(txs.len(), 1, "There should be exactly one transaction");
     assert_eq!(txs[0].tx_type, "purchase");
     assert_eq!(txs[0].amount, CONTENT_PRICE_MICRO);
@@ -365,8 +356,7 @@ async fn pik_generation_and_node_id_derivation() {
 async fn content_chunking_and_merkle_verification() {
     // Test with multi-chunk content.
     let large_data = vec![0xABu8; chunker::CHUNK_SIZE * 3 + 500];
-    let result = chunker::split_content(&large_data)
-        .expect("Multi-chunk splitting should succeed");
+    let result = chunker::split_content(&large_data).expect("Multi-chunk splitting should succeed");
 
     assert_eq!(result.chunks.len(), 4, "3.x chunks should split into 4");
     assert_eq!(result.chunks[0].data.len(), chunker::CHUNK_SIZE);

--- a/crates/ochra-integration-tests/tests/network_bootstrap.rs
+++ b/crates/ochra-integration-tests/tests/network_bootstrap.rs
@@ -147,34 +147,23 @@ async fn network_bootstrap_three_nodes() {
     // Results should be sorted by XOR distance.
     let d0 = RoutingTable::xor_distance(&closest_random[0].node_id, &random_target);
     let d1 = RoutingTable::xor_distance(&closest_random[1].node_id, &random_target);
-    assert!(
-        d0 <= d1,
-        "Results must be sorted by ascending XOR distance"
-    );
+    assert!(d0 <= d1, "Results must be sorted by ascending XOR distance");
 
     // =========================================================
     // Step 5: XOR distance properties
     // =========================================================
     // Self-distance is zero.
     let self_dist = RoutingTable::xor_distance(&node_a.node_id, &node_a.node_id);
-    assert_eq!(
-        self_dist,
-        [0u8; 32],
-        "XOR distance to self must be zero"
-    );
+    assert_eq!(self_dist, [0u8; 32], "XOR distance to self must be zero");
 
     // Symmetry: d(A,B) == d(B,A).
     let d_ab = RoutingTable::xor_distance(&node_a.node_id, &node_b.node_id);
     let d_ba = RoutingTable::xor_distance(&node_b.node_id, &node_a.node_id);
-    assert_eq!(
-        d_ab, d_ba,
-        "XOR distance must be symmetric"
-    );
+    assert_eq!(d_ab, d_ba, "XOR distance must be symmetric");
 
     // Non-zero for different nodes.
     assert_ne!(
-        d_ab,
-        [0u8; 32],
+        d_ab, [0u8; 32],
         "XOR distance between different nodes must be non-zero"
     );
 
@@ -186,11 +175,7 @@ async fn network_bootstrap_three_nodes() {
         matches!(update_result, AddNodeResult::Updated),
         "Re-adding an existing node should update, not insert"
     );
-    assert_eq!(
-        rt_a.len(),
-        2,
-        "Table size should not change after update"
-    );
+    assert_eq!(rt_a.len(), 2, "Table size should not change after update");
 
     // =========================================================
     // Step 7: Node removal
@@ -275,13 +260,9 @@ async fn dht_record_store_mutable() {
     let salt = b"test-mutable-salt";
 
     // Create mutable record with seq=1.
-    let record_v1 = bep44::create_mutable_record(
-        &kp.signing_key,
-        salt,
-        1,
-        b"value version 1".to_vec(),
-    )
-    .expect("Mutable record v1 creation should succeed");
+    let record_v1 =
+        bep44::create_mutable_record(&kp.signing_key, salt, 1, b"value version 1".to_vec())
+            .expect("Mutable record v1 creation should succeed");
 
     let key = record_v1.storage_key();
 
@@ -307,13 +288,9 @@ async fn dht_record_store_mutable() {
         .expect("Store mutable record v1 should succeed");
 
     // Update to seq=2 should succeed.
-    let record_v2 = bep44::create_mutable_record(
-        &kp.signing_key,
-        salt,
-        2,
-        b"value version 2".to_vec(),
-    )
-    .expect("Mutable record v2 creation should succeed");
+    let record_v2 =
+        bep44::create_mutable_record(&kp.signing_key, salt, 2, b"value version 2".to_vec())
+            .expect("Mutable record v2 creation should succeed");
 
     store
         .put(record_v2)
@@ -327,13 +304,9 @@ async fn dht_record_store_mutable() {
     );
 
     // Stale sequence (seq=1) should be rejected.
-    let stale_record = bep44::create_mutable_record(
-        &kp.signing_key,
-        salt,
-        1,
-        b"stale attempt".to_vec(),
-    )
-    .expect("Stale record creation should succeed");
+    let stale_record =
+        bep44::create_mutable_record(&kp.signing_key, salt, 1, b"stale attempt".to_vec())
+            .expect("Stale record creation should succeed");
 
     let stale_result = store.put(stale_record);
     assert!(
@@ -342,13 +315,9 @@ async fn dht_record_store_mutable() {
     );
 
     // Equal sequence (seq=2) should also be rejected.
-    let equal_seq_record = bep44::create_mutable_record(
-        &kp.signing_key,
-        salt,
-        2,
-        b"equal seq attempt".to_vec(),
-    )
-    .expect("Equal-seq record creation should succeed");
+    let equal_seq_record =
+        bep44::create_mutable_record(&kp.signing_key, salt, 2, b"equal seq attempt".to_vec())
+            .expect("Equal-seq record creation should succeed");
 
     let equal_result = store.put(equal_seq_record);
     assert!(
@@ -357,13 +326,9 @@ async fn dht_record_store_mutable() {
     );
 
     // Forward sequence (seq=3) should succeed.
-    let record_v3 = bep44::create_mutable_record(
-        &kp.signing_key,
-        salt,
-        3,
-        b"value version 3".to_vec(),
-    )
-    .expect("Mutable record v3 creation should succeed");
+    let record_v3 =
+        bep44::create_mutable_record(&kp.signing_key, salt, 3, b"value version 3".to_vec())
+            .expect("Mutable record v3 creation should succeed");
 
     store
         .put(record_v3)
@@ -379,13 +344,9 @@ async fn dht_record_store_tamper_detection() {
     // Verify that tampered mutable records are rejected.
     let kp = ed25519::KeyPair::generate();
 
-    let mut record = bep44::create_mutable_record(
-        &kp.signing_key,
-        b"salt",
-        1,
-        b"original value".to_vec(),
-    )
-    .expect("Record creation should succeed");
+    let mut record =
+        bep44::create_mutable_record(&kp.signing_key, b"salt", 1, b"original value".to_vec())
+            .expect("Record creation should succeed");
 
     // Tamper with the value.
     if let DhtRecord::Mutable { ref mut value, .. } = record {
@@ -433,7 +394,10 @@ async fn dht_record_store_expiration() {
     assert_eq!(store.len(), 1, "Store should have 1 record");
 
     // Record is accessible immediately.
-    assert!(store.get(&key).is_some(), "Record should be accessible before TTL");
+    assert!(
+        store.get(&key).is_some(),
+        "Record should be accessible before TTL"
+    );
 
     // Wait for TTL to expire.
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -473,10 +437,7 @@ async fn find_node_lookup_convergence() {
 
     // Get seed nodes from routing table.
     let seed_nodes = rt.find_closest(&target, 3);
-    assert!(
-        !seed_nodes.is_empty(),
-        "Should have seed nodes for lookup"
-    );
+    assert!(!seed_nodes.is_empty(), "Should have seed nodes for lookup");
 
     let mut lookup = FindNodeLookup::new(target, seed_nodes);
     assert!(
@@ -516,10 +477,7 @@ async fn find_node_lookup_convergence() {
     );
 
     let results = lookup.results();
-    assert!(
-        !results.is_empty(),
-        "Lookup should produce results"
-    );
+    assert!(!results.is_empty(), "Lookup should produce results");
 
     // Results should be sorted by distance to target.
     for i in 0..results.len().saturating_sub(1) {
@@ -612,11 +570,7 @@ async fn bucket_full_eviction() {
             // Simulate failed ping to LRS node -> evict and insert new node.
             rt.evict_and_insert(&least_recently_seen.node_id, overflow_node)
                 .expect("Eviction should succeed");
-            assert_eq!(
-                rt.len(),
-                k,
-                "Table size should remain K after eviction"
-            );
+            assert_eq!(rt.len(), k, "Table size should remain K after eviction");
         }
         other => panic!("Expected BucketFull, got {:?}", other),
     }

--- a/crates/ochra-integration-tests/tests/recovery_flow.rs
+++ b/crates/ochra-integration-tests/tests/recovery_flow.rs
@@ -122,11 +122,7 @@ async fn recovery_full_lifecycle_3_of_5() {
         let hb = heartbeat::publish_heartbeat(guardian.pik_hash, BASE_TIME);
         assert_eq!(hb.guardian_id, guardian.pik_hash);
 
-        let status = heartbeat::check_heartbeat(
-            &guardian.pik_hash,
-            hb.timestamp,
-            BASE_TIME + 1000,
-        );
+        let status = heartbeat::check_heartbeat(&guardian.pik_hash, hb.timestamp, BASE_TIME + 1000);
         assert_eq!(
             status,
             heartbeat::HealthStatus::Healthy,
@@ -136,10 +132,7 @@ async fn recovery_full_lifecycle_3_of_5() {
         // Verify dead drop address is deterministic.
         let addr1 = heartbeat::derive_dead_drop_addr(&guardian.pik_hash, 1);
         let addr2 = heartbeat::derive_dead_drop_addr(&guardian.pik_hash, 1);
-        assert_eq!(
-            addr1, addr2,
-            "Dead drop address must be deterministic"
-        );
+        assert_eq!(addr1, addr2, "Dead drop address must be deterministic");
 
         // Different epochs produce different addresses.
         let addr3 = heartbeat::derive_dead_drop_addr(&guardian.pik_hash, 2);
@@ -320,10 +313,7 @@ async fn recovery_veto_cancels_process() {
 
     // Double veto must fail.
     let double_veto_result = recovery::submit_veto(&mut request);
-    assert!(
-        double_veto_result.is_err(),
-        "Double veto must be rejected"
-    );
+    assert!(double_veto_result.is_err(), "Double veto must be rejected");
 
     // Shares cannot be submitted even after veto window expires.
     let share = GuardianShare {
@@ -366,10 +356,7 @@ async fn guardian_heartbeat_health_transitions() {
         heartbeat_time,
         heartbeat_time + heartbeat::MAX_HEARTBEAT_AGE + 1,
     );
-    assert_eq!(
-        status_unresponsive,
-        heartbeat::HealthStatus::Unresponsive
-    );
+    assert_eq!(status_unresponsive, heartbeat::HealthStatus::Unresponsive);
 }
 
 #[tokio::test]
@@ -377,16 +364,15 @@ async fn guardian_heartbeat_health_transitions() {
 async fn dkg_edge_cases() {
     // Test: threshold equals guardian count (n-of-n).
     let guardians = make_test_guardians(3);
-    let mut dkg_n_of_n = dkg::initiate_dkg(guardians.clone(), 3)
-        .expect("3-of-3 DKG should succeed");
+    let mut dkg_n_of_n =
+        dkg::initiate_dkg(guardians.clone(), 3).expect("3-of-3 DKG should succeed");
     dkg_n_of_n
         .process_shares()
         .expect("Processing should succeed");
     assert!(dkg_n_of_n.is_complete());
 
     // Test: threshold = 1 (any single guardian can recover).
-    let mut dkg_1_of_3 = dkg::initiate_dkg(guardians, 1)
-        .expect("1-of-3 DKG should succeed");
+    let mut dkg_1_of_3 = dkg::initiate_dkg(guardians, 1).expect("1-of-3 DKG should succeed");
     dkg_1_of_3
         .process_shares()
         .expect("Processing should succeed");
@@ -407,9 +393,10 @@ async fn dkg_edge_cases() {
 
     // Test: cannot process shares twice.
     let guardians4 = make_test_guardians(4);
-    let mut dkg_double = dkg::initiate_dkg(guardians4, 2)
-        .expect("DKG should initiate");
-    dkg_double.process_shares().expect("First process should succeed");
+    let mut dkg_double = dkg::initiate_dkg(guardians4, 2).expect("DKG should initiate");
+    dkg_double
+        .process_shares()
+        .expect("First process should succeed");
     let second_process = dkg_double.process_shares();
     assert!(
         second_process.is_err(),
@@ -444,10 +431,7 @@ async fn recovery_database_persistence() {
             row.get(0)
         })
         .expect("Count query should succeed");
-    assert_eq!(
-        count, 3,
-        "Should have 3 recovery contacts in the database"
-    );
+    assert_eq!(count, 3, "Should have 3 recovery contacts in the database");
 
     // Verify we can retrieve by PIK hash.
     let found: bool = conn

--- a/crates/ochra-integration-tests/tests/whisper_e2e.rs
+++ b/crates/ochra-integration-tests/tests/whisper_e2e.rs
@@ -230,20 +230,14 @@ async fn whisper_session_full_lifecycle() {
     .to_string();
 
     let transfer_nonce = message_nonce(&alice_nonce_prefix, 3);
-    let encrypted_transfer = chacha20::encrypt_no_aad(
-        &alice_key,
-        &transfer_nonce,
-        transfer_payload.as_bytes(),
-    )
-    .expect("Transfer payload encryption should succeed");
+    let encrypted_transfer =
+        chacha20::encrypt_no_aad(&alice_key, &transfer_nonce, transfer_payload.as_bytes())
+            .expect("Transfer payload encryption should succeed");
 
     // Bob decrypts the transfer.
-    let decrypted_transfer = chacha20::decrypt_no_aad(
-        &bob_key,
-        &transfer_nonce,
-        &encrypted_transfer,
-    )
-    .expect("Transfer payload decryption should succeed");
+    let decrypted_transfer =
+        chacha20::decrypt_no_aad(&bob_key, &transfer_nonce, &encrypted_transfer)
+            .expect("Transfer payload decryption should succeed");
     let parsed: serde_json::Value =
         serde_json::from_slice(&decrypted_transfer).expect("Transfer JSON should parse");
     assert_eq!(
@@ -263,12 +257,15 @@ async fn whisper_session_full_lifecycle() {
     .expect("Bob token insertion should succeed");
 
     // Verify balances.
-    let alice_balance = ochra_db::queries::wallet::balance(&alice.db)
-        .expect("Alice balance query should succeed");
-    assert_eq!(alice_balance, 0, "Alice should have zero balance after spend");
+    let alice_balance =
+        ochra_db::queries::wallet::balance(&alice.db).expect("Alice balance query should succeed");
+    assert_eq!(
+        alice_balance, 0,
+        "Alice should have zero balance after spend"
+    );
 
-    let bob_balance = ochra_db::queries::wallet::balance(&bob.db)
-        .expect("Bob balance query should succeed");
+    let bob_balance =
+        ochra_db::queries::wallet::balance(&bob.db).expect("Bob balance query should succeed");
     assert_eq!(
         bob_balance, transfer_amount,
         "Bob should have received the transfer amount"
@@ -384,8 +381,8 @@ async fn whisper_message_tamper_detection() {
     let nonce = message_nonce(&nonce_prefix, 1);
 
     let plaintext = b"Sensitive whisper content";
-    let ciphertext = chacha20::encrypt_no_aad(&enc_key, &nonce, plaintext)
-        .expect("Encryption should succeed");
+    let ciphertext =
+        chacha20::encrypt_no_aad(&enc_key, &nonce, plaintext).expect("Encryption should succeed");
 
     // Tamper with the ciphertext.
     let mut tampered = ciphertext.clone();

--- a/crates/ochra-invite/src/contact_exchange.rs
+++ b/crates/ochra-invite/src/contact_exchange.rs
@@ -143,8 +143,7 @@ pub fn redeem_token(
 
 /// Encode a contact exchange token to a base64 string for sharing.
 pub fn encode_token(token: &ContactExchangeToken) -> Result<String> {
-    let json =
-        serde_json::to_vec(token).map_err(|e| InviteError::Serialization(e.to_string()))?;
+    let json = serde_json::to_vec(token).map_err(|e| InviteError::Serialization(e.to_string()))?;
     Ok(base64::Engine::encode(
         &base64::engine::general_purpose::URL_SAFE_NO_PAD,
         &json,
@@ -153,11 +152,8 @@ pub fn encode_token(token: &ContactExchangeToken) -> Result<String> {
 
 /// Decode a contact exchange token from a base64 string.
 pub fn decode_token(encoded: &str) -> Result<ContactExchangeToken> {
-    let json = base64::Engine::decode(
-        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        encoded,
-    )
-    .map_err(|e| InviteError::Malformed(format!("invalid base64: {}", e)))?;
+    let json = base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, encoded)
+        .map_err(|e| InviteError::Malformed(format!("invalid base64: {}", e)))?;
 
     serde_json::from_slice(&json)
         .map_err(|e| InviteError::Malformed(format!("invalid token JSON: {}", e)))
@@ -193,12 +189,7 @@ mod tests {
         let x_secret = X25519StaticSecret::random();
         let x_pk = x_secret.public_key();
 
-        let token = generate_token(
-            &kp.signing_key,
-            [0xAAu8; 32],
-            "Alice",
-            x_pk.to_bytes(),
-        );
+        let token = generate_token(&kp.signing_key, [0xAAu8; 32], "Alice", x_pk.to_bytes());
 
         (token, kp)
     }

--- a/crates/ochra-invite/src/invite.rs
+++ b/crates/ochra-invite/src/invite.rs
@@ -135,10 +135,7 @@ pub fn create_invite_link(
 
     let json =
         serde_json::to_vec(&invite).map_err(|e| InviteError::Serialization(e.to_string()))?;
-    let encoded = base64::Engine::encode(
-        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        &json,
-    );
+    let encoded = base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, &json);
 
     Ok(format!("{INVITE_SCHEME}{encoded}"))
 }
@@ -160,11 +157,8 @@ pub fn parse_invite_link(url: &str) -> Result<InviteLink> {
         .strip_prefix(INVITE_SCHEME)
         .ok_or_else(|| InviteError::InvalidUrl("missing ochra://invite/ prefix".to_string()))?;
 
-    let json = base64::Engine::decode(
-        &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-        payload,
-    )
-    .map_err(|e| InviteError::InvalidUrl(format!("base64 decode error: {}", e)))?;
+    let json = base64::Engine::decode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, payload)
+        .map_err(|e| InviteError::InvalidUrl(format!("base64 decode error: {}", e)))?;
 
     let invite: InviteLink = serde_json::from_slice(&json)
         .map_err(|e| InviteError::Malformed(format!("invalid invite JSON: {}", e)))?;
@@ -297,10 +291,8 @@ mod tests {
         tampered.space_name = "Tampered Space".to_string();
 
         let json = serde_json::to_vec(&tampered).expect("serialize");
-        let encoded = base64::Engine::encode(
-            &base64::engine::general_purpose::URL_SAFE_NO_PAD,
-            &json,
-        );
+        let encoded =
+            base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, &json);
         let tampered_url = format!("{INVITE_SCHEME}{encoded}");
 
         let result = parse_invite_link(&tampered_url);

--- a/crates/ochra-invite/src/rendezvous.rs
+++ b/crates/ochra-invite/src/rendezvous.rs
@@ -351,7 +351,8 @@ mod tests {
     #[test]
     fn test_intro_point_retire() {
         let mut mgr = IntroPointManager::new(3);
-        mgr.establish([0x01u8; 32], [0x10u8; 32]).expect("establish");
+        mgr.establish([0x01u8; 32], [0x10u8; 32])
+            .expect("establish");
         assert_eq!(mgr.active_count(), 1);
 
         mgr.retire(&[0x01u8; 32]);
@@ -361,7 +362,8 @@ mod tests {
     #[test]
     fn test_intro_point_mark_failed() {
         let mut mgr = IntroPointManager::new(3);
-        mgr.establish([0x01u8; 32], [0x10u8; 32]).expect("establish");
+        mgr.establish([0x01u8; 32], [0x10u8; 32])
+            .expect("establish");
         mgr.mark_failed(&[0x01u8; 32]);
         assert_eq!(mgr.active_count(), 0);
     }
@@ -379,7 +381,8 @@ mod tests {
     #[test]
     fn test_intro_point_record_introduction() {
         let mut mgr = IntroPointManager::new(3);
-        mgr.establish([0x01u8; 32], [0x10u8; 32]).expect("establish");
+        mgr.establish([0x01u8; 32], [0x10u8; 32])
+            .expect("establish");
         mgr.record_introduction(&[0x01u8; 32]);
         mgr.record_introduction(&[0x01u8; 32]);
         assert_eq!(mgr.active_count(), 1);

--- a/crates/ochra-mint/src/groth16_mint.rs
+++ b/crates/ochra-mint/src/groth16_mint.rs
@@ -68,11 +68,8 @@ pub fn generate_minting_proof(input: &MintingProofInput) -> Result<SerializedPro
     // Stub proof: BLAKE3::hash(merkle_root || total_amount || epoch)
     let amount_bytes = input.total_amount.to_le_bytes();
     let epoch_bytes = input.epoch.to_le_bytes();
-    let fields = blake3::encode_multi_field(&[
-        &input.receipt_merkle_root[..],
-        &amount_bytes,
-        &epoch_bytes,
-    ]);
+    let fields =
+        blake3::encode_multi_field(&[&input.receipt_merkle_root[..], &amount_bytes, &epoch_bytes]);
     let proof_hash = blake3::hash(&fields);
 
     tracing::debug!(
@@ -94,10 +91,7 @@ pub fn generate_minting_proof(input: &MintingProofInput) -> Result<SerializedPro
 /// # Returns
 ///
 /// `true` if the proof is valid, `false` otherwise.
-pub fn verify_minting_proof(
-    proof: &SerializedProof,
-    public_inputs: &MintingPublicInputs,
-) -> bool {
+pub fn verify_minting_proof(proof: &SerializedProof, public_inputs: &MintingPublicInputs) -> bool {
     if public_inputs.total_amount == 0 || public_inputs.receipt_merkle_root == [0u8; 32] {
         return false;
     }

--- a/crates/ochra-mint/src/voprf_mint.rs
+++ b/crates/ochra-mint/src/voprf_mint.rs
@@ -113,17 +113,13 @@ impl MintClient {
     /// # Errors
     ///
     /// - [`MintError::Voprf`] if the unblinding operation fails
-    pub fn unblind(
-        evaluated: &EvaluatedToken,
-        state: &MintBlindState,
-    ) -> Result<UnblindedToken> {
+    pub fn unblind(evaluated: &EvaluatedToken, state: &MintBlindState) -> Result<UnblindedToken> {
         let eval_element = EvaluatedElement {
             bytes: evaluated.evaluated_element.clone(),
         };
 
-        let output =
-            voprf::finalize(&state.blind_state, &eval_element)
-                .map_err(|e| MintError::Voprf(e.to_string()))?;
+        let output = voprf::finalize(&state.blind_state, &eval_element)
+            .map_err(|e| MintError::Voprf(e.to_string()))?;
 
         Ok(UnblindedToken {
             serial: state.serial,
@@ -143,10 +139,7 @@ impl MintServer {
     /// # Errors
     ///
     /// - [`MintError::Voprf`] if the evaluation fails
-    pub fn evaluate(
-        blinded: &BlindedToken,
-        server_key: &VoprfServerKey,
-    ) -> Result<EvaluatedToken> {
+    pub fn evaluate(blinded: &BlindedToken, server_key: &VoprfServerKey) -> Result<EvaluatedToken> {
         let blinded_element = BlindedElement {
             bytes: blinded.blinded_element.clone(),
         };
@@ -177,11 +170,8 @@ impl UnblindedToken {
     /// `commitment = BLAKE3::hash(serial || voprf_output || denomination_le)`
     pub fn commitment(&self) -> [u8; 32] {
         let denom_bytes = self.denomination.to_le_bytes();
-        let fields = blake3::encode_multi_field(&[
-            &self.serial[..],
-            &self.voprf_output,
-            &denom_bytes,
-        ]);
+        let fields =
+            blake3::encode_multi_field(&[&self.serial[..], &self.voprf_output, &denom_bytes]);
         blake3::hash(&fields)
     }
 }

--- a/crates/ochra-mls/src/group.rs
+++ b/crates/ochra-mls/src/group.rs
@@ -445,9 +445,7 @@ mod tests {
         let (mut group, _) = add_member(group, kp2).expect("add");
 
         let plaintext = b"Hello, group!";
-        let ciphertext = group
-            .encrypt_message(&[1; 32], plaintext)
-            .expect("encrypt");
+        let ciphertext = group.encrypt_message(&[1; 32], plaintext).expect("encrypt");
 
         let decrypted = group.decrypt_message(&ciphertext).expect("decrypt");
         assert_eq!(decrypted, plaintext);

--- a/crates/ochra-nullifier/src/gossip.rs
+++ b/crates/ochra-nullifier/src/gossip.rs
@@ -123,11 +123,7 @@ mod tests {
 
     #[test]
     fn test_create_gossip_message() {
-        let msg = create_gossip_message(
-            vec![[0x01; 32], [0x02; 32]],
-            42,
-            [0xAA; 32],
-        );
+        let msg = create_gossip_message(vec![[0x01; 32], [0x02; 32]], 42, [0xAA; 32]);
         assert_eq!(msg.nullifiers.len(), 2);
         assert_eq!(msg.epoch, 42);
         assert_eq!(msg.sender_id, [0xAA; 32]);

--- a/crates/ochra-onion/src/circuit.rs
+++ b/crates/ochra-onion/src/circuit.rs
@@ -203,8 +203,7 @@ pub fn derive_hop_keys(shared_secret: &[u8; 32]) -> HopKeys {
     let hop_key = ochra_crypto::blake3::derive_key(contexts::SPHINX_HOP_KEY, shared_secret);
     let hop_mac = ochra_crypto::blake3::derive_key(contexts::SPHINX_HOP_MAC, shared_secret);
     let hop_pad = ochra_crypto::blake3::derive_key(contexts::SPHINX_HOP_PAD, shared_secret);
-    let nonce_full =
-        ochra_crypto::blake3::derive_key(contexts::SPHINX_HOP_NONCE, shared_secret);
+    let nonce_full = ochra_crypto::blake3::derive_key(contexts::SPHINX_HOP_NONCE, shared_secret);
 
     let mut hop_nonce = [0u8; 12];
     hop_nonce.copy_from_slice(&nonce_full[..12]);
@@ -318,10 +317,7 @@ mod tests {
     fn test_circuit_builder_insufficient_relays() {
         let r1 = make_relay_descriptor(1);
 
-        let result = CircuitBuilder::new()
-            .add_relay(r1)
-            .expect("add r1")
-            .build();
+        let result = CircuitBuilder::new().add_relay(r1).expect("add r1").build();
 
         assert!(result.is_err());
         assert!(matches!(

--- a/crates/ochra-onion/src/cover.rs
+++ b/crates/ochra-onion/src/cover.rs
@@ -61,8 +61,7 @@ impl CoverTrafficConfig {
     /// The interval is clamped to `[MIN_COVER_INTERVAL_MS, MAX_COVER_INTERVAL_MS]`.
     pub fn new(mean_interval_ms: u64) -> Self {
         Self {
-            mean_interval_ms: mean_interval_ms
-                .clamp(MIN_COVER_INTERVAL_MS, MAX_COVER_INTERVAL_MS),
+            mean_interval_ms: mean_interval_ms.clamp(MIN_COVER_INTERVAL_MS, MAX_COVER_INTERVAL_MS),
             enabled: true,
         }
     }
@@ -111,7 +110,8 @@ impl CoverTrafficGenerator {
     /// Draws from an exponential distribution (Poisson inter-arrival time)
     /// using the configured mean interval.
     pub fn next_delay(&self) -> Duration {
-        let u: f64 = rand::Rng::gen_range(&mut rand::thread_rng(), f64::EPSILON..(1.0 - f64::EPSILON));
+        let u: f64 =
+            rand::Rng::gen_range(&mut rand::thread_rng(), f64::EPSILON..(1.0 - f64::EPSILON));
         let delay_ms = next_cover_delay_ms(self.config.mean_interval_ms, u);
         Duration::from_millis(delay_ms)
     }

--- a/crates/ochra-onion/src/nat.rs
+++ b/crates/ochra-onion/src/nat.rs
@@ -198,18 +198,13 @@ pub fn can_hole_punch(nat_type: &NatType) -> bool {
 ///
 /// Tries hole-punching first, falls back to relay if the NAT type
 /// prevents direct connectivity.
-pub fn attempt_traversal(
-    _peer_address: &str,
-    nat_type: &NatType,
-) -> Result<TraversalResult> {
+pub fn attempt_traversal(_peer_address: &str, nat_type: &NatType) -> Result<TraversalResult> {
     match nat_type {
         NatType::None => Ok(TraversalResult::Direct),
         NatType::FullCone | NatType::AddressRestrictedCone | NatType::PortRestrictedCone => {
             Ok(TraversalResult::HolePunched)
         }
-        NatType::Symmetric | NatType::Unknown => {
-            Ok(TraversalResult::Relayed)
-        }
+        NatType::Symmetric | NatType::Unknown => Ok(TraversalResult::Relayed),
     }
 }
 

--- a/crates/ochra-onion/src/relay.rs
+++ b/crates/ochra-onion/src/relay.rs
@@ -47,9 +47,7 @@ pub struct RelayCache {
 impl RelayCache {
     /// Create a new empty relay cache.
     pub fn new() -> Self {
-        Self {
-            relays: Vec::new(),
-        }
+        Self { relays: Vec::new() }
     }
 
     /// Create a relay cache from a list of descriptors.
@@ -119,10 +117,7 @@ impl RelaySelector {
     ///
     /// Uses PoSrv-weighted random sampling with constraint enforcement.
     /// Returns an ordered list: `[entry, middle, exit]`.
-    pub fn select_relays(
-        &self,
-        cache: &RelayCache,
-    ) -> Result<Vec<RelayDescriptor>> {
+    pub fn select_relays(&self, cache: &RelayCache) -> Result<Vec<RelayDescriptor>> {
         let available = cache.all();
 
         if available.len() < CIRCUIT_HOPS {
@@ -219,9 +214,7 @@ impl RelaySelector {
             }
         }
 
-        debug!(
-            "Selected {} relays for circuit", selected.len()
-        );
+        debug!("Selected {} relays for circuit", selected.len());
 
         Ok(selected)
     }
@@ -260,14 +253,9 @@ fn extract_subnet_24(addr_str: &str) -> Option<[u8; 3]> {
 /// Select a relay using PoSrv-weighted random sampling.
 ///
 /// Relays with higher PoSrv scores are more likely to be selected.
-fn weighted_select<'a>(
-    relays: &[&'a &RelayDescriptor],
-) -> Result<&'a RelayDescriptor> {
+fn weighted_select<'a>(relays: &[&'a &RelayDescriptor]) -> Result<&'a RelayDescriptor> {
     if relays.is_empty() {
-        return Err(OnionError::InsufficientRelays {
-            need: 1,
-            have: 0,
-        });
+        return Err(OnionError::InsufficientRelays { need: 1, have: 0 });
     }
 
     // Compute total weight (PoSrv scores, clamped to positive).
@@ -319,14 +307,8 @@ mod tests {
 
     #[test]
     fn test_extract_subnet_24() {
-        assert_eq!(
-            extract_subnet_24("192.168.1.100:4433"),
-            Some([192, 168, 1])
-        );
-        assert_eq!(
-            extract_subnet_24("10.0.0.1:4433"),
-            Some([10, 0, 0])
-        );
+        assert_eq!(extract_subnet_24("192.168.1.100:4433"), Some([192, 168, 1]));
+        assert_eq!(extract_subnet_24("10.0.0.1:4433"), Some([10, 0, 0]));
         assert_eq!(extract_subnet_24("invalid"), None);
     }
 
@@ -403,10 +385,7 @@ mod tests {
         for relay in &selected {
             let subnet = extract_subnet_24(&relay.ip_addr);
             if let Some(s) = subnet {
-                assert!(
-                    subnets.insert(s),
-                    "Duplicate /24 subnet in selected relays"
-                );
+                assert!(subnets.insert(s), "Duplicate /24 subnet in selected relays");
             }
         }
     }

--- a/crates/ochra-oracle/src/circuit_breaker.rs
+++ b/crates/ochra-oracle/src/circuit_breaker.rs
@@ -163,7 +163,9 @@ mod tests {
     #[test]
     fn test_check_operational_stale() {
         let cb = CircuitBreaker::new(1000);
-        let err = cb.check_operational(1000 + STALENESS_THRESHOLD + 1).unwrap_err();
+        let err = cb
+            .check_operational(1000 + STALENESS_THRESHOLD + 1)
+            .unwrap_err();
         assert!(matches!(err, OracleError::StaleData { .. }));
     }
 
@@ -171,7 +173,9 @@ mod tests {
     fn test_check_operational_paused_takes_priority() {
         let mut cb = CircuitBreaker::new(1000);
         cb.trigger_pause();
-        let err = cb.check_operational(1000 + STALENESS_THRESHOLD + 1).unwrap_err();
+        let err = cb
+            .check_operational(1000 + STALENESS_THRESHOLD + 1)
+            .unwrap_err();
         // Pause check comes before staleness check
         assert!(matches!(err, OracleError::Paused));
     }

--- a/crates/ochra-oracle/src/denomination.rs
+++ b/crates/ochra-oracle/src/denomination.rs
@@ -69,7 +69,10 @@ mod tests {
     fn test_baseline_denomination() {
         // At baseline: twap = 1 Seed in micro-seeds, infra_metric = 1
         let denom = compute_denomination(MICRO_SEEDS_PER_SEED, 1).expect("baseline denom");
-        assert_eq!(denom, MICRO_SEEDS_PER_SEED as u64 * MICRO_SEEDS_PER_SEED as u64);
+        assert_eq!(
+            denom,
+            MICRO_SEEDS_PER_SEED as u64 * MICRO_SEEDS_PER_SEED as u64
+        );
     }
 
     #[test]

--- a/crates/ochra-oracle/src/lib.rs
+++ b/crates/ochra-oracle/src/lib.rs
@@ -48,7 +48,9 @@ pub enum OracleError {
     EmptyWindow,
 
     /// Oracle data is stale beyond the staleness threshold.
-    #[error("oracle data is stale: last update {last_update}, current {current}, threshold {threshold}")]
+    #[error(
+        "oracle data is stale: last update {last_update}, current {current}, threshold {threshold}"
+    )]
     StaleData {
         /// Timestamp of the last update.
         last_update: u64,

--- a/crates/ochra-oracle/src/twap.rs
+++ b/crates/ochra-oracle/src/twap.rs
@@ -116,7 +116,10 @@ mod tests {
         let err = compute_twap(&prices).unwrap_err();
         assert!(matches!(
             err,
-            OracleError::InsufficientObservations { required: 3, available: 2 }
+            OracleError::InsufficientObservations {
+                required: 3,
+                available: 2
+            }
         ));
     }
 
@@ -126,7 +129,10 @@ mod tests {
         let err = compute_twap(&prices).unwrap_err();
         assert!(matches!(
             err,
-            OracleError::NonMonotonicTimestamp { new: 2000, last: 3000 }
+            OracleError::NonMonotonicTimestamp {
+                new: 2000,
+                last: 3000
+            }
         ));
     }
 
@@ -135,18 +141,17 @@ mod tests {
         let err = compute_twap(&[]).unwrap_err();
         assert!(matches!(
             err,
-            OracleError::InsufficientObservations { required: 3, available: 0 }
+            OracleError::InsufficientObservations {
+                required: 3,
+                available: 0
+            }
         ));
     }
 
     #[test]
     fn test_large_values() {
         // Ensure no overflow for large u64 prices
-        let prices = vec![
-            (0, u64::MAX / 2),
-            (1, u64::MAX / 2),
-            (2, u64::MAX / 2),
-        ];
+        let prices = vec![(0, u64::MAX / 2), (1, u64::MAX / 2), (2, u64::MAX / 2)];
         let twap = compute_twap(&prices).expect("large values TWAP");
         assert_eq!(twap, u64::MAX / 2);
     }

--- a/crates/ochra-posrv/src/sybilguard.rs
+++ b/crates/ochra-posrv/src/sybilguard.rs
@@ -127,9 +127,10 @@ impl TrustGraph {
     ///
     /// Trust weight in [0.0, 1.0].
     pub fn compute_trust_weight(&self, node_id: &[u8; 32]) -> Result<f64> {
-        let node_data = self.nodes.get(node_id).ok_or_else(|| {
-            PoSrvError::NodeNotFound(hex::encode(node_id))
-        })?;
+        let node_data = self
+            .nodes
+            .get(node_id)
+            .ok_or_else(|| PoSrvError::NodeNotFound(hex::encode(node_id)))?;
 
         // If the node has no outgoing edges, trust is 0.
         if node_data.edges.is_empty() {

--- a/crates/ochra-pow/src/argon2id_pow.rs
+++ b/crates/ochra-pow/src/argon2id_pow.rs
@@ -102,9 +102,8 @@ pub fn solve_pow(challenge: &PowChallenge, content_hash: &[u8; 32]) -> Result<Po
 ///
 /// `true` if the proof is valid, `false` otherwise.
 pub fn verify_pow(challenge: &PowChallenge, solution: &PowSolution) -> bool {
-    let mut data = Vec::with_capacity(
-        challenge.nonce_prefix.len() + challenge.target_hash.len() + 32,
-    );
+    let mut data =
+        Vec::with_capacity(challenge.nonce_prefix.len() + challenge.target_hash.len() + 32);
     data.extend_from_slice(&challenge.nonce_prefix);
     data.extend_from_slice(&challenge.target_hash);
     // Note: content_hash is embedded in the target_hash for verification

--- a/crates/ochra-pow/src/lib.rs
+++ b/crates/ochra-pow/src/lib.rs
@@ -21,7 +21,9 @@ pub enum PowError {
     Argon2(String),
 
     /// The proof did not meet the required difficulty target.
-    #[error("proof does not meet difficulty target (need {required} leading zero bits, got {actual})")]
+    #[error(
+        "proof does not meet difficulty target (need {required} leading zero bits, got {actual})"
+    )]
     InsufficientDifficulty {
         /// Required number of leading zero bits.
         required: u32,

--- a/crates/ochra-pow/src/zk_por.rs
+++ b/crates/ochra-pow/src/zk_por.rs
@@ -88,10 +88,7 @@ pub fn generate_por_proof(input: &PorProofInput) -> Result<SerializedProof> {
 /// # Returns
 ///
 /// `true` if the proof is valid, `false` otherwise.
-pub fn verify_por_proof(
-    proof: &SerializedProof,
-    public_inputs: &PorPublicInputs,
-) -> bool {
+pub fn verify_por_proof(proof: &SerializedProof, public_inputs: &PorPublicInputs) -> bool {
     if public_inputs.chunk_indices.len() != public_inputs.chunk_hashes.len() {
         return false;
     }

--- a/crates/ochra-revenue/src/splits.rs
+++ b/crates/ochra-revenue/src/splits.rs
@@ -15,7 +15,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{RevenueError, Result};
+use crate::{Result, RevenueError};
 
 /// Timelock duration for split changes (30 days in seconds).
 pub const TIMELOCK_SECONDS: u64 = 30 * 24 * 3600;
@@ -129,10 +129,7 @@ pub fn is_effective(proposal: &SplitChangeProposal, current_time: u64) -> bool {
 ///
 /// - [`RevenueError::ZeroAmount`] if the amount is zero
 /// - [`RevenueError::InvalidSplitTotal`] if the split is invalid
-pub fn distribute(
-    amount: u64,
-    split: &RevenueSplitConfig,
-) -> Result<(u64, u64, u64)> {
+pub fn distribute(amount: u64, split: &RevenueSplitConfig) -> Result<(u64, u64, u64)> {
     if amount == 0 {
         return Err(RevenueError::ZeroAmount);
     }

--- a/crates/ochra-spend/src/blind_receipt.rs
+++ b/crates/ochra-spend/src/blind_receipt.rs
@@ -7,7 +7,7 @@
 use ochra_crypto::blake3;
 use serde::{Deserialize, Serialize};
 
-use crate::{SpendError, Result};
+use crate::{Result, SpendError};
 
 /// A blind receipt for a content purchase.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -57,10 +57,7 @@ pub fn generate_receipt(content_hash: &[u8; 32], amount: u64) -> Result<BlindRec
 
     // Derive receipt ID from the blinded content hash and amount
     let amount_bytes = amount.to_le_bytes();
-    let fields = blake3::encode_multi_field(&[
-        &blinded_content_hash[..],
-        &amount_bytes,
-    ]);
+    let fields = blake3::encode_multi_field(&[&blinded_content_hash[..], &amount_bytes]);
     let receipt_id = blake3::hash(&fields);
 
     let timestamp = std::time::SystemTime::now()

--- a/crates/ochra-spend/src/macro_tx.rs
+++ b/crates/ochra-spend/src/macro_tx.rs
@@ -7,7 +7,7 @@
 use ochra_crypto::blake3;
 use serde::{Deserialize, Serialize};
 
-use crate::{SpendError, Result};
+use crate::{Result, SpendError};
 
 /// Escrow timeout in seconds.
 pub const ESCROW_TIMEOUT: u64 = 60;
@@ -129,17 +129,11 @@ pub fn finalize_macro(escrow: &mut EscrowHandle) -> Result<MacroReceipt> {
 
     // Compute transaction hash
     let amount_bytes = escrow.amount.to_le_bytes();
-    let fields = blake3::encode_multi_field(&[
-        &escrow.escrow_id[..],
-        &escrow.nullifier[..],
-        &amount_bytes,
-    ]);
+    let fields =
+        blake3::encode_multi_field(&[&escrow.escrow_id[..], &escrow.nullifier[..], &amount_bytes]);
     let tx_hash = blake3::hash(&fields);
 
-    tracing::info!(
-        amount = escrow.amount,
-        "macro transaction: finalized"
-    );
+    tracing::info!(amount = escrow.amount, "macro transaction: finalized");
 
     Ok(MacroReceipt {
         tx_hash,

--- a/crates/ochra-spend/src/micro.rs
+++ b/crates/ochra-spend/src/micro.rs
@@ -10,7 +10,7 @@
 use ochra_crypto::blake3;
 use serde::{Deserialize, Serialize};
 
-use crate::{SpendError, Result};
+use crate::{Result, SpendError};
 
 /// Fee rate for micro transactions (0.1%).
 pub const FEE_RATE: f64 = 0.001;
@@ -75,11 +75,7 @@ pub fn execute_micro(tx: &MicroTransaction) -> Result<Receipt> {
 
     // Compute transaction hash
     let amount_bytes = tx.amount.to_le_bytes();
-    let fields = blake3::encode_multi_field(&[
-        &tx.nullifier[..],
-        &amount_bytes,
-        &tx.blind_token,
-    ]);
+    let fields = blake3::encode_multi_field(&[&tx.nullifier[..], &amount_bytes, &tx.blind_token]);
     let tx_hash = blake3::hash(&fields);
 
     let timestamp = current_timestamp();
@@ -108,7 +104,11 @@ pub fn compute_fee(amount: u64) -> u64 {
     }
     let fee = (amount as f64 * FEE_RATE) as u64;
     // Minimum fee is 1 micro-seed
-    if fee == 0 { 1 } else { fee }
+    if fee == 0 {
+        1
+    } else {
+        fee
+    }
 }
 
 /// Get the current Unix timestamp in seconds.

--- a/crates/ochra-storage/src/abr.rs
+++ b/crates/ochra-storage/src/abr.rs
@@ -141,9 +141,10 @@ impl AbrStore {
     /// * `chunk_id` - The 32-byte chunk identifier.
     /// * `current_time` - The current Unix timestamp (used to update dynamic age).
     pub fn get_chunk(&mut self, chunk_id: &[u8; 32], current_time: u64) -> Result<&[u8]> {
-        let entry = self.entries.get_mut(chunk_id).ok_or_else(|| {
-            StorageError::ChunkNotFound(hex::encode(chunk_id))
-        })?;
+        let entry = self
+            .entries
+            .get_mut(chunk_id)
+            .ok_or_else(|| StorageError::ChunkNotFound(hex::encode(chunk_id)))?;
 
         entry.meta.access_count += 1;
         entry.meta.dynamic_age = current_time;

--- a/crates/ochra-storage/src/chunker.rs
+++ b/crates/ochra-storage/src/chunker.rs
@@ -303,9 +303,7 @@ mod tests {
 
     #[test]
     fn test_merkle_proof_four_leaves() {
-        let leaves: Vec<[u8; 32]> = (0..4u8)
-            .map(|i| blake3::merkle_leaf(&[i]))
-            .collect();
+        let leaves: Vec<[u8; 32]> = (0..4u8).map(|i| blake3::merkle_leaf(&[i])).collect();
         let root = build_merkle_root(&leaves);
 
         for i in 0..4 {
@@ -319,9 +317,7 @@ mod tests {
 
     #[test]
     fn test_merkle_proof_three_leaves_odd() {
-        let leaves: Vec<[u8; 32]> = (0..3u8)
-            .map(|i| blake3::merkle_leaf(&[i]))
-            .collect();
+        let leaves: Vec<[u8; 32]> = (0..3u8).map(|i| blake3::merkle_leaf(&[i])).collect();
         let root = build_merkle_root(&leaves);
 
         for i in 0..3 {

--- a/crates/ochra-storage/src/reed_solomon.rs
+++ b/crates/ochra-storage/src/reed_solomon.rs
@@ -98,10 +98,7 @@ impl ReedSolomonCodec {
     /// # Returns
     ///
     /// The original concatenated data (all 4 data shards joined).
-    pub fn decode(
-        &self,
-        shards: &[Option<Vec<u8>>; TOTAL_SHARDS],
-    ) -> Result<Vec<u8>> {
+    pub fn decode(&self, shards: &[Option<Vec<u8>>; TOTAL_SHARDS]) -> Result<Vec<u8>> {
         let present_count = shards.iter().filter(|s| s.is_some()).count();
         if present_count < DATA_SHARDS {
             return Err(StorageError::ReedSolomonDecode(format!(
@@ -113,9 +110,7 @@ impl ReedSolomonCodec {
             .iter()
             .flatten()
             .next()
-            .ok_or_else(|| {
-                StorageError::ReedSolomonDecode("no shards present".to_string())
-            })?
+            .ok_or_else(|| StorageError::ReedSolomonDecode("no shards present".to_string()))?
             .len();
 
         // Try to recover each data shard.
@@ -197,9 +192,7 @@ impl ReedSolomonCodec {
         let mut result = Vec::with_capacity(shard_len * DATA_SHARDS);
         for (i, shard) in recovered.iter().enumerate() {
             let data = shard.as_ref().ok_or_else(|| {
-                StorageError::ReedSolomonDecode(format!(
-                    "unable to recover data shard {i}"
-                ))
+                StorageError::ReedSolomonDecode(format!("unable to recover data shard {i}"))
             })?;
             result.extend_from_slice(data);
         }
@@ -220,9 +213,7 @@ impl ReedSolomonCodec {
     /// 4 data shards of equal length and the original (unpadded) data length.
     pub fn split_into_data_shards(&self, data: &[u8]) -> Result<([Vec<u8>; DATA_SHARDS], usize)> {
         if data.is_empty() {
-            return Err(StorageError::ReedSolomonEncode(
-                "data is empty".to_string(),
-            ));
+            return Err(StorageError::ReedSolomonEncode("data is empty".to_string()));
         }
 
         let original_len = data.len();

--- a/crates/ochra-testvec/src/main.rs
+++ b/crates/ochra-testvec/src/main.rs
@@ -78,10 +78,8 @@ fn generate_blake3_vectors() -> BTreeMap<String, TestVector> {
     );
 
     // Vector 4: Keyed hash (Merkle inner node)
-    let k_inner = ochra_crypto::blake3::derive_key(
-        ochra_crypto::blake3::contexts::MERKLE_INNER_NODE,
-        b"",
-    );
+    let k_inner =
+        ochra_crypto::blake3::derive_key(ochra_crypto::blake3::contexts::MERKLE_INNER_NODE, b"");
     let mac = ochra_crypto::blake3::keyed_hash(&k_inner, &[0u8; 64]);
     vectors.insert(
         "blake3_keyed_hash_merkle".to_string(),
@@ -179,10 +177,9 @@ fn generate_hybrid_session_vector() -> BTreeMap<String, TestVector> {
     let mut vectors = BTreeMap::new();
 
     // RFC 7748 Section 6.1 shared secret
-    let x25519_shared = hex::decode(
-        "4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742",
-    )
-    .expect("valid hex");
+    let x25519_shared =
+        hex::decode("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742")
+            .expect("valid hex");
 
     let mlkem_shared = [0u8; 31].iter().chain(&[1u8]).copied().collect::<Vec<u8>>();
     let mut mlkem_bytes = [0u8; 32];
@@ -205,10 +202,7 @@ fn generate_hybrid_session_vector() -> BTreeMap<String, TestVector> {
                 ("x25519_shared".to_string(), hex::encode(&x25519_shared)),
                 ("mlkem768_shared".to_string(), hex::encode(&mlkem_bytes)),
             ]),
-            outputs: BTreeMap::from([(
-                "session_secret".to_string(),
-                hex::encode(session_secret),
-            )]),
+            outputs: BTreeMap::from([("session_secret".to_string(), hex::encode(session_secret))]),
         },
     );
 
@@ -231,7 +225,10 @@ fn generate_ecies_vector() -> BTreeMap<String, TestVector> {
         TestVector {
             description: "ECIES-X25519-ChaCha20-BLAKE3 deterministic encryption".to_string(),
             inputs: BTreeMap::from([
-                ("recipient_pk".to_string(), hex::encode(recipient_pk.to_bytes())),
+                (
+                    "recipient_pk".to_string(),
+                    hex::encode(recipient_pk.to_bytes()),
+                ),
                 ("plaintext".to_string(), hex::encode(plaintext)),
                 ("randomness".to_string(), hex::encode(randomness)),
             ]),
@@ -270,8 +267,7 @@ fn generate_ratchet_vectors() -> BTreeMap<String, TestVector> {
     vectors.insert(
         "ratchet_root_kdf".to_string(),
         TestVector {
-            description: "Double Ratchet root KDF: KDF_RK(rk=0x00*32, dh_out=0xFF*32)"
-                .to_string(),
+            description: "Double Ratchet root KDF: KDF_RK(rk=0x00*32, dh_out=0xFF*32)".to_string(),
             inputs: BTreeMap::from([
                 ("rk".to_string(), hex::encode(rk)),
                 ("dh_out".to_string(), hex::encode(dh_out)),
@@ -285,14 +281,10 @@ fn generate_ratchet_vectors() -> BTreeMap<String, TestVector> {
 
     // Chain KDF
     let ck = [0u8; 32];
-    let new_ck = ochra_crypto::blake3::derive_key(
-        ochra_crypto::blake3::contexts::RATCHET_CHAIN_KEY,
-        &ck,
-    );
-    let msg_key = ochra_crypto::blake3::derive_key(
-        ochra_crypto::blake3::contexts::RATCHET_MSG_KEY,
-        &ck,
-    );
+    let new_ck =
+        ochra_crypto::blake3::derive_key(ochra_crypto::blake3::contexts::RATCHET_CHAIN_KEY, &ck);
+    let msg_key =
+        ochra_crypto::blake3::derive_key(ochra_crypto::blake3::contexts::RATCHET_MSG_KEY, &ck);
 
     vectors.insert(
         "ratchet_chain_kdf".to_string(),
@@ -325,7 +317,9 @@ fn generate_bloom_filter_vector() -> BTreeMap<String, TestVector> {
 
     let mut indices = Vec::new();
     for i in 0u64..20 {
-        let bit_index = (h1.wrapping_add(i.wrapping_mul(h2)).wrapping_add(i.wrapping_mul(i)))
+        let bit_index = (h1
+            .wrapping_add(i.wrapping_mul(h2))
+            .wrapping_add(i.wrapping_mul(i)))
             % filter_size_bits;
         indices.push(bit_index.to_string());
     }
@@ -398,8 +392,7 @@ fn main() {
         let path = "tests/fixtures/test_vectors.json";
         match std::fs::read_to_string(path) {
             Ok(content) => {
-                let vectors: TestVectors =
-                    serde_json::from_str(&content).expect("valid JSON");
+                let vectors: TestVectors = serde_json::from_str(&content).expect("valid JSON");
                 if verify_vectors(&vectors) {
                     eprintln!("All test vectors verified successfully.");
                     std::process::exit(0);

--- a/crates/ochra-transport/src/cbor.rs
+++ b/crates/ochra-transport/src/cbor.rs
@@ -16,9 +16,8 @@ use crate::TransportError;
 /// Returns [`TransportError::Serialization`] if the value cannot be serialized.
 pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, TransportError> {
     let mut buf = Vec::new();
-    ciborium::into_writer(value, &mut buf).map_err(|e| {
-        TransportError::Serialization(format!("CBOR serialization failed: {e}"))
-    })?;
+    ciborium::into_writer(value, &mut buf)
+        .map_err(|e| TransportError::Serialization(format!("CBOR serialization failed: {e}")))?;
     Ok(buf)
 }
 
@@ -29,9 +28,8 @@ pub fn to_vec<T: Serialize>(value: &T) -> Result<Vec<u8>, TransportError> {
 /// Returns [`TransportError::Deserialization`] if the bytes cannot be deserialized
 /// into the target type.
 pub fn from_slice<T: DeserializeOwned>(data: &[u8]) -> Result<T, TransportError> {
-    ciborium::from_reader(data).map_err(|e| {
-        TransportError::Deserialization(format!("CBOR deserialization failed: {e}"))
-    })
+    ciborium::from_reader(data)
+        .map_err(|e| TransportError::Deserialization(format!("CBOR deserialization failed: {e}")))
 }
 
 /// Serialize a value to CBOR bytes, returning an error with context.
@@ -41,9 +39,7 @@ pub fn from_slice<T: DeserializeOwned>(data: &[u8]) -> Result<T, TransportError>
 pub fn to_vec_named<T: Serialize>(value: &T, type_name: &str) -> Result<Vec<u8>, TransportError> {
     let mut buf = Vec::new();
     ciborium::into_writer(value, &mut buf).map_err(|e| {
-        TransportError::Serialization(format!(
-            "CBOR serialization of {type_name} failed: {e}"
-        ))
+        TransportError::Serialization(format!("CBOR serialization of {type_name} failed: {e}"))
     })?;
     Ok(buf)
 }
@@ -57,9 +53,7 @@ pub fn from_slice_named<T: DeserializeOwned>(
     type_name: &str,
 ) -> Result<T, TransportError> {
     ciborium::from_reader(data).map_err(|e| {
-        TransportError::Deserialization(format!(
-            "CBOR deserialization of {type_name} failed: {e}"
-        ))
+        TransportError::Deserialization(format!("CBOR deserialization of {type_name} failed: {e}"))
     })
 }
 
@@ -103,9 +97,7 @@ mod tests {
 
     #[test]
     fn test_cbor_is_compact() {
-        let ping = Ping {
-            nonce: [0; 8],
-        };
+        let ping = Ping { nonce: [0; 8] };
         let cbor = to_vec(&ping).expect("serialize");
         let json = serde_json::to_vec(&ping).expect("serialize json");
         // CBOR should generally be more compact than JSON

--- a/crates/ochra-transport/src/messages.rs
+++ b/crates/ochra-transport/src/messages.rs
@@ -893,10 +893,7 @@ mod tests {
         assert_eq!(GoodbyeReason::from_u8(0), GoodbyeReason::Normal);
         assert_eq!(GoodbyeReason::from_u8(1), GoodbyeReason::ProtocolViolation);
         assert_eq!(GoodbyeReason::from_u8(2), GoodbyeReason::Timeout);
-        assert_eq!(
-            GoodbyeReason::from_u8(3),
-            GoodbyeReason::TooManyConnections
-        );
+        assert_eq!(GoodbyeReason::from_u8(3), GoodbyeReason::TooManyConnections);
         assert_eq!(GoodbyeReason::from_u8(4), GoodbyeReason::AuthFailure);
         assert_eq!(GoodbyeReason::from_u8(99), GoodbyeReason::Other);
         assert_eq!(GoodbyeReason::from_u8(255), GoodbyeReason::Other);

--- a/crates/ochra-vys/src/accounting.rs
+++ b/crates/ochra-vys/src/accounting.rs
@@ -12,7 +12,7 @@
 
 use serde::{Deserialize, Serialize};
 
-use crate::{VysError, Result};
+use crate::{Result, VysError};
 
 /// VYS reward accumulator for a single node.
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/crates/ochra-vys/src/claims.rs
+++ b/crates/ochra-vys/src/claims.rs
@@ -6,7 +6,7 @@
 use serde::{Deserialize, Serialize};
 
 use crate::accounting::VysAccumulator;
-use crate::{VysError, Result};
+use crate::{Result, VysError};
 
 /// A request to claim accumulated VYS rewards.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -39,10 +39,7 @@ pub struct ClaimResult {
 ///
 /// - [`VysError::NoRewards`] if the accumulator has no claimable rewards
 /// - [`VysError::InvalidProof`] if the claim fails verification
-pub fn process_claim(
-    request: &ClaimRequest,
-    accumulator: &mut VysAccumulator,
-) -> Result<u64> {
+pub fn process_claim(request: &ClaimRequest, accumulator: &mut VysAccumulator) -> Result<u64> {
     if !verify_claim(request) {
         return Err(VysError::InvalidProof(
             "claim verification failed".to_string(),
@@ -66,17 +63,11 @@ pub fn process_claim(
         accumulator.reset_rewards(request.epoch);
     } else {
         // Partial claim: reduce accumulated rewards
-        accumulator.accumulated_rewards = accumulator
-            .accumulated_rewards
-            .saturating_sub(disbursed);
+        accumulator.accumulated_rewards = accumulator.accumulated_rewards.saturating_sub(disbursed);
         accumulator.last_claim_epoch = request.epoch;
     }
 
-    tracing::info!(
-        disbursed,
-        epoch = request.epoch,
-        "VYS claim processed"
-    );
+    tracing::info!(disbursed, epoch = request.epoch, "VYS claim processed");
 
     Ok(disbursed)
 }


### PR DESCRIPTION
Run `cargo fmt --all` across the workspace to fix all rustfmt formatting issues flagged by CI.

https://claude.ai/code/session_01USfXuV1bGzgWrFGxvuTpJV