### PR TITLE
Fix all clippy warnings across the workspace

### DIFF
--- a/crates/ochra-crypto/src/frost.rs
+++ b/crates/ochra-crypto/src/frost.rs
@@ -56,7 +56,7 @@ pub fn dkg(
     max_signers: u16,
     min_signers: u16,
 ) -> Result<(Vec<FrostKeyPackage>, FrostPublicKeyPackage)> {
-    let mut rng = OsRng;
+    let rng = OsRng;
 
     // Use the trusted dealer key generation for simplicity in v1
     // (Production should use the 3-round DKG from Section 12.6)
@@ -64,7 +64,7 @@ pub fn dkg(
         max_signers,
         min_signers,
         frost::keys::IdentifierList::Default,
-        &mut rng,
+        rng,
     )
     .map_err(|e| CryptoError::Frost(e.to_string()))?;
 

--- a/crates/ochra-crypto/src/poseidon.rs
+++ b/crates/ochra-crypto/src/poseidon.rs
@@ -68,12 +68,12 @@ fn generate_mds_matrix() -> Vec<Vec<Fr>> {
     let mut matrix = vec![vec![Fr::from(0u64); t]; t];
 
     // Cauchy matrix: M[i][j] = 1 / (x_i + y_j) where x_i = i, y_j = t + j
-    for i in 0..t {
-        for j in 0..t {
+    for (i, row) in matrix.iter_mut().enumerate().take(t) {
+        for (j, cell) in row.iter_mut().enumerate().take(t) {
             let x = Fr::from((i + 1) as u64);
             let y = Fr::from((t + j + 1) as u64);
             let sum = x + y;
-            matrix[i][j] = sum.inverse().unwrap_or(Fr::from(0u64));
+            *cell = sum.inverse().unwrap_or(Fr::from(0u64));
         }
     }
 
@@ -126,14 +126,14 @@ fn poseidon_permutation(params: &PoseidonParams, a: Fr, b: Fr) -> Fr {
     // First half of full rounds
     for _ in 0..half_f {
         // Add round constants
-        for j in 0..t {
-            state[j] += params.round_constants[rc_idx + j];
+        for (j, s) in state.iter_mut().enumerate().take(t) {
+            *s += params.round_constants[rc_idx + j];
         }
         rc_idx += t;
 
         // Full S-box layer
-        for j in 0..t {
-            state[j] = sbox(state[j]);
+        for s in state.iter_mut().take(t) {
+            *s = sbox(*s);
         }
 
         // MDS matrix multiplication
@@ -143,8 +143,8 @@ fn poseidon_permutation(params: &PoseidonParams, a: Fr, b: Fr) -> Fr {
     // Partial rounds
     for _ in 0..r_p {
         // Add round constants
-        for j in 0..t {
-            state[j] += params.round_constants[rc_idx + j];
+        for (j, s) in state.iter_mut().enumerate().take(t) {
+            *s += params.round_constants[rc_idx + j];
         }
         rc_idx += t;
 
@@ -158,14 +158,14 @@ fn poseidon_permutation(params: &PoseidonParams, a: Fr, b: Fr) -> Fr {
     // Second half of full rounds
     for _ in 0..half_f {
         // Add round constants
-        for j in 0..t {
-            state[j] += params.round_constants[rc_idx + j];
+        for (j, s) in state.iter_mut().enumerate().take(t) {
+            *s += params.round_constants[rc_idx + j];
         }
         rc_idx += t;
 
         // Full S-box layer
-        for j in 0..t {
-            state[j] = sbox(state[j]);
+        for s in state.iter_mut().take(t) {
+            *s = sbox(*s);
         }
 
         // MDS matrix multiplication

--- a/crates/ochra-daemon/src/commands/identity.rs
+++ b/crates/ochra-daemon/src/commands/identity.rs
@@ -129,7 +129,7 @@ pub async fn get_my_pik(state: &Arc<DaemonState>) -> Result {
 }
 
 /// Change password.
-pub async fn change_password(state: &Arc<DaemonState>, params: &Value) -> Result {
+pub async fn change_password(_state: &Arc<DaemonState>, params: &Value) -> Result {
     let _old = params
         .get("old")
         .and_then(|v| v.as_str())

--- a/crates/ochra-daemon/src/config.rs
+++ b/crates/ochra-daemon/src/config.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// Complete daemon configuration (Section 33).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct DaemonConfig {
     /// Network settings.
     #[serde(default)]
@@ -128,18 +128,6 @@ fn default_session_timeout() -> u32 {
 
 fn default_log_level() -> String {
     "info".to_string()
-}
-
-impl Default for DaemonConfig {
-    fn default() -> Self {
-        Self {
-            network: NetworkConfig::default(),
-            storage: StorageConfig::default(),
-            identity: IdentityConfig::default(),
-            privacy: PrivacyConfig::default(),
-            advanced: AdvancedConfig::default(),
-        }
-    }
 }
 
 impl Default for NetworkConfig {

--- a/crates/ochra-daemon/src/epoch.rs
+++ b/crates/ochra-daemon/src/epoch.rs
@@ -3,9 +3,7 @@
 //! All periodic operations execute at epoch boundaries (00:00 UTC).
 //! This module manages the epoch scheduler.
 
-use std::sync::Arc;
-
-use tracing::{info, warn};
+use tracing::info;
 
 /// Epoch duration in seconds (24 hours).
 pub const EPOCH_DURATION_SECS: u64 = 24 * 60 * 60;
@@ -32,6 +30,7 @@ pub fn current_relay_epoch() -> u64 {
 }
 
 /// Get seconds until the next epoch boundary.
+#[allow(dead_code)]
 pub fn seconds_until_next_epoch() -> u64 {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -41,6 +40,7 @@ pub fn seconds_until_next_epoch() -> u64 {
 }
 
 /// Get seconds until the next relay epoch boundary.
+#[allow(dead_code)]
 pub fn seconds_until_next_relay_epoch() -> u64 {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
@@ -67,6 +67,7 @@ pub fn seconds_until_next_relay_epoch() -> u64 {
 /// 13. Timelock expiry check
 /// 14. Metrics aggregation
 /// 15. Database WAL checkpoint
+#[allow(dead_code)]
 pub async fn run_epoch_boundary() {
     let epoch = current_epoch();
     info!(epoch, "Running epoch boundary operations");

--- a/crates/ochra-daemon/src/events.rs
+++ b/crates/ochra-daemon/src/events.rs
@@ -22,6 +22,7 @@ pub struct Event {
 }
 
 /// Filter for event subscriptions.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EventFilter {
     /// Category filter: "space", "economy", "system", "whisper".
@@ -33,6 +34,7 @@ pub struct EventFilter {
 }
 
 /// A subscription handle.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubscriptionId(pub String);
 
@@ -73,6 +75,7 @@ impl EventBus {
 
 impl EventFilter {
     /// Check if an event matches this filter.
+    #[allow(dead_code)]
     pub fn matches(&self, event: &Event) -> bool {
         // Category filter
         if let Some(ref categories) = self.categories {
@@ -96,6 +99,7 @@ impl EventFilter {
 }
 
 /// Categorize an event type into a category.
+#[allow(dead_code)]
 fn categorize_event(event_type: &str) -> String {
     match event_type {
         s if s.starts_with("Member")

--- a/crates/ochra-daemon/src/main.rs
+++ b/crates/ochra-daemon/src/main.rs
@@ -9,11 +9,10 @@ mod epoch;
 mod events;
 mod rpc;
 
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use tokio::sync::{broadcast, mpsc, RwLock};
-use tracing::{error, info, warn};
+use tokio::sync::{broadcast, RwLock};
+use tracing::{error, info};
 
 use crate::config::DaemonConfig;
 use crate::events::EventBus;
@@ -53,11 +52,7 @@ async fn main() -> anyhow::Result<()> {
 
     // 2. Open database
     let db_path = data_dir.join("ochra.db");
-    let conn = if db_path.exists() {
-        ochra_db::open(&db_path)?
-    } else {
-        ochra_db::open(&db_path)?
-    };
+    let conn = ochra_db::open(&db_path)?;
     let db = Arc::new(tokio::sync::Mutex::new(conn));
 
     // 3. Create event bus

--- a/crates/ochra-daemon/src/rpc.rs
+++ b/crates/ochra-daemon/src/rpc.rs
@@ -18,6 +18,7 @@ use crate::DaemonState;
 #[derive(Debug, Deserialize)]
 pub struct RpcRequest {
     /// JSON-RPC version (must be "2.0").
+    #[allow(dead_code)]
     pub jsonrpc: String,
     /// Request ID.
     pub id: serde_json::Value,
@@ -89,6 +90,7 @@ impl RpcError {
     }
 
     /// Invalid request (-32600).
+    #[allow(dead_code)]
     pub fn invalid_request() -> Self {
         Self {
             code: -32600,
@@ -161,6 +163,7 @@ impl RpcError {
     }
 
     /// Not host (-32060).
+    #[allow(dead_code)]
     pub fn not_host() -> Self {
         Self {
             code: -32060,

--- a/crates/ochra-db/src/migrations.rs
+++ b/crates/ochra-db/src/migrations.rs
@@ -68,14 +68,12 @@ fn insert_default_settings(conn: &Connection) -> Result<()> {
 }
 
 /// Run a specific migration.
-fn run_migration(conn: &Connection, version: u32) -> Result<()> {
-    match version {
-        // Future migrations go here:
-        // 2 => migration_v2(conn),
-        _ => Err(DbError::Migration(format!(
-            "Unknown migration version: {version}"
-        ))),
-    }
+fn run_migration(_conn: &Connection, version: u32) -> Result<()> {
+    // Future migrations go here:
+    // 2 => migration_v2(conn),
+    Err(DbError::Migration(format!(
+        "Unknown migration version: {version}"
+    )))
 }
 
 #[cfg(test)]

--- a/crates/ochra-db/src/queries.rs
+++ b/crates/ochra-db/src/queries.rs
@@ -5,5 +5,3 @@ pub mod content;
 pub mod settings;
 pub mod spaces;
 pub mod wallet;
-
-use crate::Result;

--- a/crates/ochra-db/src/queries/content.rs
+++ b/crates/ochra-db/src/queries/content.rs
@@ -2,9 +2,10 @@
 
 use rusqlite::Connection;
 
-use crate::{DbError, Result};
+use crate::Result;
 
 /// Insert a content item.
+#[allow(clippy::too_many_arguments)]
 pub fn insert(
     conn: &Connection,
     content_hash: &[u8; 32],

--- a/crates/ochra-db/src/queries/spaces.rs
+++ b/crates/ochra-db/src/queries/spaces.rs
@@ -2,7 +2,7 @@
 
 use rusqlite::Connection;
 
-use crate::{DbError, Result};
+use crate::Result;
 
 /// Insert a new space.
 pub fn insert(

--- a/crates/ochra-testvec/src/main.rs
+++ b/crates/ochra-testvec/src/main.rs
@@ -200,7 +200,7 @@ fn generate_hybrid_session_vector() -> BTreeMap<String, TestVector> {
             description: "Hybrid PQC session secret derivation".to_string(),
             inputs: BTreeMap::from([
                 ("x25519_shared".to_string(), hex::encode(&x25519_shared)),
-                ("mlkem768_shared".to_string(), hex::encode(&mlkem_bytes)),
+                ("mlkem768_shared".to_string(), hex::encode(mlkem_bytes)),
             ]),
             outputs: BTreeMap::from([("session_secret".to_string(), hex::encode(session_secret))]),
         },


### PR DESCRIPTION
- Remove needless borrows in frost.rs and testvec main.rs
- Replace needless_range_loop with idiomatic iterators in poseidon.rs
- Remove unused imports in daemon (epoch.rs, main.rs) and db modules
- Prefix unused variable with underscore in identity.rs
- Add #[allow(dead_code)] for scaffolding code in daemon (epoch, events, rpc)
- Replace manual Default impl with derive in config.rs
- Simplify identical if/else branches in daemon main.rs
- Add #[allow(clippy::too_many_arguments)] for content::insert
- Simplify match with single wildcard arm in migrations.rs

https://claude.ai/code/session_01USfXuV1bGzgWrFGxvuTpJV