### PR TITLE
Add ui/src-tauri to workspace members

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/ochra-guardian",
     "crates/ochra-daemon",
     "crates/ochra-integration-tests",
+    "ui/src-tauri",
 ]
 
 [workspace.package]

--- a/ui/src-tauri/Cargo.toml
+++ b/ui/src-tauri/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 description = "Ochra desktop application (Tauri v2)"
 
-# This crate is NOT part of the workspace. It builds separately via Tauri's
-# build system. See the root Cargo.toml for the workspace members list.
-
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 


### PR DESCRIPTION
Cargo's implicit workspace discovery finds the root Cargo.toml and errors out because ui/src-tauri declares no [workspace] table and isn't listed in the root workspace. Adding it as a member fixes the `cargo metadata` failure during Tauri builds.

https://claude.ai/code/session_01USfXuV1bGzgWrFGxvuTpJV