### PR TITLE
Install GTK/WebKit deps in rust-checks CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Install system dependencies (Ubuntu)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgtk-3-dev \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+
       - name: Check formatting
         run: cargo fmt --all -- --check
 


### PR DESCRIPTION
Now that ui/src-tauri is a workspace member, workspace-wide commands (clippy, test, fmt) need the GTK and WebKit system libraries installed to compile glib-sys and other native dependencies.

https://claude.ai/code/session_01USfXuV1bGzgWrFGxvuTpJV