### PR TITLE
Fix identity creation by calling correct RPC method

### DIFF
--- a/ui/src/pages/setup/Welcome.tsx
+++ b/ui/src/pages/setup/Welcome.tsx
@@ -26,12 +26,12 @@ export default function Welcome() {
     if (!canProceed) return;
     setError("");
 
-    const result = await call("create_identity", {
-      display_name: name.trim(),
-      password,
-    });
+    const result = await call("init_pik", { password });
 
     if (result) {
+      // Session is now unlocked — save display name
+      await call("update_display_name", { new_name: name.trim() });
+
       setAuth({
         unlocked: true,
         displayName: name.trim(),


### PR DESCRIPTION
The frontend was calling "create_identity" which doesn't exist in the daemon's RPC dispatcher. Changed to call "init_pik" (the actual method) followed by "update_display_name" to save the user's chosen name.

https://claude.ai/code/session_01USfXuV1bGzgWrFGxvuTpJV